### PR TITLE
Add collaborator support

### DIFF
--- a/examples/collaborators.rs
+++ b/examples/collaborators.rs
@@ -1,0 +1,45 @@
+extern crate env_logger;
+extern crate hyper;
+extern crate hubcaps;
+
+use hyper::Client;
+use hubcaps::{Credentials, Github};
+use std::env;
+
+fn main() {
+    env_logger::init().unwrap();
+    match env::var("GITHUB_TOKEN").ok() {
+        Some(token) => {
+            let client = Client::new();
+            let github = Github::new(format!("hubcaps/{}", env!("CARGO_PKG_VERSION")),
+                                     &client,
+                                     Credentials::Token(token));
+
+            println!("My organizations:");
+            println!("");
+
+            for org in github.orgs().list().unwrap() {
+                println!("{}", org.login);
+                println!("=============");
+                println!("Repos:");
+
+                for repo in github.org_repos(&org.login[..]).list(&Default::default()).unwrap() {
+                    println!("* {}", repo.name);
+
+                    // If you have push permissions on an org, you can list collaborators.
+                    // Otherwise, don't print them.
+                    if let Ok(collabs) = github.repo(
+                            &org.login[..],
+                            &repo.name[..]
+                        ).collaborators().list() {
+                        println!("  * Collaborators: {}", collabs.into_iter().map(|c| {
+                            c.login
+                        }).collect::<Vec<_>>().join(", "));
+                    }
+                }
+                println!("")
+            }
+        }
+        _ => println!("example missing GITHUB_TOKEN"),
+    }
+}

--- a/src/collaborators.rs
+++ b/src/collaborators.rs
@@ -1,0 +1,29 @@
+use rep::User;
+use self::super::{Github, Result};
+
+pub struct Collaborators<'a> {
+    github: &'a Github<'a>,
+    owner: String,
+    repo: String,
+}
+
+impl<'a> Collaborators<'a> {
+    pub fn new<O, R>(github: &'a Github<'a>, owner: O, repo: R) -> Collaborators<'a>
+        where O: Into<String>,
+              R: Into<String>
+    {
+        Collaborators {
+            github: github,
+            owner: owner.into(),
+            repo: repo.into(),
+        }
+    }
+
+    fn path(&self, more: &str) -> String {
+        format!("/repos/{}/{}/collaborators{}", self.owner, self.repo, more)
+    }
+
+    pub fn list(&self) -> Result<Vec<User>> {
+        self.github.get::<Vec<User>>(&self.path(""))
+    }
+}

--- a/src/collaborators.rs
+++ b/src/collaborators.rs
@@ -1,5 +1,6 @@
 use rep::User;
-use self::super::{Github, Result};
+use self::super::{Github, Result, Error};
+use hyper::status::StatusCode;
 
 pub struct Collaborators<'a> {
     github: &'a Github<'a>,
@@ -25,5 +26,13 @@ impl<'a> Collaborators<'a> {
 
     pub fn list(&self) -> Result<Vec<User>> {
         self.github.get::<Vec<User>>(&self.path(""))
+    }
+
+    pub fn is_collaborator(&self, username: &str) -> Result<bool> {
+        match self.github.get::<()>(&self.path(&format!("/{}", username))) {
+            Ok(_) => Ok(true),
+            Err(Error::Fault { code: c, .. }) if c == StatusCode::NotFound => Ok(false),
+            Err(other) => Err(other),
+        }
     }
 }

--- a/src/collaborators.rs
+++ b/src/collaborators.rs
@@ -78,4 +78,8 @@ impl<'a> Collaborators<'a> {
         )
     }
 
+    pub fn remove(&self, username: &str) -> Result<()> {
+        self.github.delete(&self.path(&format!("/{}", username)))
+    }
+
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -251,6 +251,7 @@ impl<'a> Github<'a> {
                     error: try!(serde_json::from_str::<ClientError>(&body)),
                 })
             }
+            StatusCode::NoContent => Ok(try!(serde_json::from_str::<D>("null"))),
             _ => Ok(try!(serde_json::from_str::<D>(&body))),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ pub mod repositories;
 pub mod statuses;
 pub mod pulls;
 pub mod organizations;
+pub mod collaborators;
 
 pub use rep::*;
 pub use errors::Error;

--- a/src/rep.rs.in
+++ b/src/rep.rs.in
@@ -431,7 +431,7 @@ pub struct Repo {
     pub has_wiki: bool,
     pub has_pages: bool,
     pub has_downloads: bool,
-    pub pushed_at: String,
+    pub pushed_at: Option<String>,
     pub created_at: String,
     pub updated_at: String, // permissions: Permissions
 }

--- a/src/repositories.rs
+++ b/src/repositories.rs
@@ -10,6 +10,7 @@ use pulls::PullRequests;
 use releases::Releases;
 use rep::{Repo, RepoOptions, RepoListOptions, UserRepoListOptions, OrganizationRepoListOptions};
 use statuses::Statuses;
+use collaborators::Collaborators;
 use std::fmt;
 
 /// describes repository visibilities
@@ -276,5 +277,11 @@ impl<'a> Repository<'a> {
     /// associated with this reposoitory ref
     pub fn statuses(&self) -> Statuses {
         Statuses::new(self.github, self.owner.as_str(), self.repo.as_str())
+    }
+
+    /// get a reference to the [collaborators](https://developer.github.com/v3/repos/collaborators/)
+    /// associated with this repository ref
+    pub fn collaborators(&self) -> Collaborators {
+        Collaborators::new(self.github, self.owner.as_ref(), self.repo.as_ref())
     }
 }


### PR DESCRIPTION
I warned you more was coming!! ;)

This PR is a little bigger than my previous ones-- let me know if you'd like me to split this up. I'm not sure if [this](https://github.com/softprops/hubcaps/commit/dd4e75b6de2f44b882d5b1d8732dc361c5c63082) is how you'd like to handle successful requests that return no content, but it works!

This adds support for all the [collaborator API requests](https://developer.github.com/v3/repos/collaborators/): list, check, add, and remove.

I added an example that lists collaborators, but because you need to have push access to an organization repo and be willing to add someone else as a collaborator, I thought that wouldn't be so great for people to expect to pull down and run. But here's the code I was testing with, I'm up for adding it as an example with some error handling/documentation if you'd like:

```
            // Must be an organization repo you have push access to
            let repo = github.repo("rustbeltrust", "2016");
            // Must be a username you're willing to add as a collaborator
            let username = "eeyoretriage";

            println!("Collaborators before: {:#?}", repo.collaborators().list());

            repo.collaborators().add(username, &Default::default()).unwrap();

            println!("Collaborators after adding: {:#?}", repo.collaborators().list());

            repo.collaborators().remove(username).unwrap();

            println!("Collaborators after removing: {:#?}", repo.collaborators().list());
```
