### PR TITLE
Add Repository Creation Endpoint

### DIFF
--- a/src/rep.rs.in
+++ b/src/rep.rs.in
@@ -476,19 +476,120 @@ pub struct RepoOptions {
     pub license_template: Option<String>,
 }
 
+#[derive(Default)]
+pub struct RepoOptionsBuilder {
+    name: String,
+    description: Option<String>,
+    homepage: Option<String>,
+    private: Option<bool>,
+    has_issues: Option<bool>,
+    has_wiki: Option<bool>,
+    has_downloads: Option<bool>,
+    team_id: Option<i32>,
+    auto_init: Option<bool>,
+    gitignore_template: Option<String>,
+    license_template: Option<String>,
+}
+
+impl RepoOptionsBuilder {
+    pub fn new<N>(name: N) -> RepoOptionsBuilder
+        where N: Into<String>
+    {
+        RepoOptionsBuilder { name: name.into(), ..Default::default() }
+    }
+
+    pub fn description<D>(&mut self, description: D) -> &mut RepoOptionsBuilder
+        where D: Into<String>
+    {
+        self.description = Some(description.into());
+        self
+    }
+
+    pub fn homepage<H>(&mut self, homepage: H) -> &mut RepoOptionsBuilder
+        where H: Into<String>
+    {
+        self.homepage = Some(homepage.into());
+        self
+    }
+
+    pub fn private(&mut self, private: bool) -> &mut RepoOptionsBuilder
+    {
+        self.private = Some(private);
+        self
+    }
+
+    pub fn has_issues(&mut self, has_issues: bool) -> &mut RepoOptionsBuilder
+    {
+        self.has_issues = Some(has_issues);
+        self
+    }
+
+    pub fn has_wiki(&mut self, has_wiki: bool) -> &mut RepoOptionsBuilder
+    {
+        self.has_wiki = Some(has_wiki);
+        self
+    }
+
+    pub fn has_downloads(&mut self, has_downloads: bool) -> &mut RepoOptionsBuilder
+    {
+        self.has_downloads = Some(has_downloads);
+        self
+    }
+
+    pub fn team_id(&mut self, team_id: i32) -> &mut RepoOptionsBuilder
+    {
+        self.team_id = Some(team_id);
+        self
+    }
+
+    pub fn auto_init(&mut self, auto_init: bool) -> &mut RepoOptionsBuilder
+    {
+        self.auto_init = Some(auto_init);
+        self
+    }
+
+    pub fn gitignore_template<GI>(&mut self, gitignore_template: GI) -> &mut RepoOptionsBuilder
+        where GI: Into<String>
+    {
+        self.gitignore_template = Some(gitignore_template.into());
+        self
+    }
+
+    pub fn license_template<L>(&mut self, license_template: L) -> &mut RepoOptionsBuilder
+        where L: Into<String>
+    {
+        self.license_template = Some(license_template.into());
+        self
+    }
+
+    pub fn build(&self) -> RepoOptions {
+        RepoOptions::new(self.name.as_ref(),
+                         self.description.clone(),
+                         self.homepage.clone(),
+                         self.private,
+                         self.has_issues,
+                         self.has_wiki,
+                         self.has_downloads,
+                         self.team_id,
+                         self.auto_init,
+                         self.gitignore_template.clone(),
+                         self.license_template.clone())
+    }
+}
+
 impl RepoOptions {
     pub fn new<N, D, H, GI, L>(name: N,
-                            description: Option<D>,
-                            homepage: Option<H>,
-                            private: Option<bool>,
-                            has_issues: Option<bool>,
-                            has_wiki: Option<bool>,
-                            has_downloads: Option<bool>,
-                            team_id: Option<i32>,
-                            auto_init: Option<bool>,
-                            gitignore_template: Option<GI>,
-                            license_template: Option<L>)
-                            -> RepoOptions
+                               description: Option<D>,
+                               homepage: Option<H>,
+                               private: Option<bool>,
+                               has_issues: Option<bool>,
+                               has_wiki: Option<bool>,
+                               has_downloads: Option<bool>,
+                               team_id: Option<i32>,
+                               auto_init: Option<bool>,
+                               gitignore_template: Option<GI>,
+                               license_template: Option<L>)
+                               -> RepoOptions
         where N: Into<String>,
               D: Into<String>,
               H: Into<String>,
@@ -508,6 +609,10 @@ impl RepoOptions {
             gitignore_template: gitignore_template.map(|gi| gi.into()),
             license_template: license_template.map(|l| l.into()),
         }
+    }
+
+    pub fn builder<N: Into<String>>(name: N) -> RepoOptionsBuilder {
+        RepoOptionsBuilder::new(name)
     }
 }
 

--- a/src/rep.rs.in
+++ b/src/rep.rs.in
@@ -467,7 +467,7 @@ pub struct RepoOptions {
     #[serde(skip_serializing_if="Option::is_none")]
     pub has_downloads: Option<bool>,
     #[serde(skip_serializing_if="Option::is_none")]
-    pub team_id: Option<u32>,
+    pub team_id: Option<i32>,
     #[serde(skip_serializing_if="Option::is_none")]
     pub auto_init: Option<bool>,
     #[serde(skip_serializing_if="Option::is_none")]
@@ -485,7 +485,7 @@ pub struct RepoOptionsBuilder {
     has_issues: Option<bool>,
     has_wiki: Option<bool>,
     has_downloads: Option<bool>,
-    team_id: Option<u32>,
+    team_id: Option<i32>,
     auto_init: Option<bool>,
     gitignore_template: Option<String>,
     license_template: Option<String>,

--- a/src/rep.rs.in
+++ b/src/rep.rs.in
@@ -450,6 +450,67 @@ impl Repo {
     }
 }
 
+
+#[derive(Debug, Serialize)]
+pub struct RepoOptions {
+    pub name: String,
+    #[serde(skip_serializing_if="Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if="Option::is_none")]
+    pub homepage: Option<String>,
+    #[serde(skip_serializing_if="Option::is_none")]
+    pub private: Option<bool>,
+    #[serde(skip_serializing_if="Option::is_none")]
+    pub has_issues: Option<bool>,
+    #[serde(skip_serializing_if="Option::is_none")]
+    pub has_wiki: Option<bool>,
+    #[serde(skip_serializing_if="Option::is_none")]
+    pub has_downloads: Option<bool>,
+    #[serde(skip_serializing_if="Option::is_none")]
+    pub team_id: Option<i32>,
+    #[serde(skip_serializing_if="Option::is_none")]
+    pub auto_init: Option<bool>,
+    #[serde(skip_serializing_if="Option::is_none")]
+    pub gitignore_template: Option<String>,
+    #[serde(skip_serializing_if="Option::is_none")]
+    pub license_template: Option<String>,
+}
+
+impl RepoOptions {
+    pub fn new<N, D, H, GI, L>(name: N,
+                            description: Option<D>,
+                            homepage: Option<H>,
+                            private: Option<bool>,
+                            has_issues: Option<bool>,
+                            has_wiki: Option<bool>,
+                            has_downloads: Option<bool>,
+                            team_id: Option<i32>,
+                            auto_init: Option<bool>,
+                            gitignore_template: Option<GI>,
+                            license_template: Option<L>)
+                            -> RepoOptions
+        where N: Into<String>,
+              D: Into<String>,
+              H: Into<String>,
+              GI: Into<String>,
+              L: Into<String>
+    {
+        RepoOptions {
+            name: name.into(),
+            description: description.map(|h| h.into()),
+            homepage: homepage.map(|h| h.into()),
+            private: private,
+            has_issues: has_issues,
+            has_wiki: has_wiki,
+            has_downloads: has_downloads,
+            team_id: team_id,
+            auto_init: auto_init,
+            gitignore_template: gitignore_template.map(|gi| gi.into()),
+            license_template: license_template.map(|l| l.into()),
+        }
+    }
+}
+
 #[derive(Debug, Deserialize)]
 pub struct RepoDetails {
     pub id: u64,

--- a/src/rep.rs.in
+++ b/src/rep.rs.in
@@ -374,7 +374,7 @@ pub struct Repo {
     pub name: String,
     pub full_name: String,
     pub description: String,
-    // private (keyword)
+    pub private: bool,
     pub fork: bool,
     pub url: String,
     pub html_url: String,

--- a/src/rep.rs.in
+++ b/src/rep.rs.in
@@ -467,7 +467,7 @@ pub struct RepoOptions {
     #[serde(skip_serializing_if="Option::is_none")]
     pub has_downloads: Option<bool>,
     #[serde(skip_serializing_if="Option::is_none")]
-    pub team_id: Option<i32>,
+    pub team_id: Option<u32>,
     #[serde(skip_serializing_if="Option::is_none")]
     pub auto_init: Option<bool>,
     #[serde(skip_serializing_if="Option::is_none")]
@@ -485,7 +485,7 @@ pub struct RepoOptionsBuilder {
     has_issues: Option<bool>,
     has_wiki: Option<bool>,
     has_downloads: Option<bool>,
-    team_id: Option<i32>,
+    team_id: Option<u32>,
     auto_init: Option<bool>,
     gitignore_template: Option<String>,
     license_template: Option<String>,

--- a/src/repositories.rs
+++ b/src/repositories.rs
@@ -1,4 +1,5 @@
 //! Repository interface
+extern crate serde_json;
 
 use self::super::{Github, Result};
 use deployments::Deployments;
@@ -7,7 +8,7 @@ use issues::{IssueRef, Issues};
 use labels::Labels;
 use pulls::PullRequests;
 use releases::Releases;
-use rep::{Repo, RepoListOptions, UserRepoListOptions, OrganizationRepoListOptions};
+use rep::{Repo, RepoOptions, RepoListOptions, UserRepoListOptions, OrganizationRepoListOptions};
 use statuses::Statuses;
 use std::fmt;
 
@@ -134,6 +135,13 @@ impl<'a> Repositories<'a> {
 
     fn path(&self, more: &str) -> String {
         format!("/user/repos{}", more)
+    }
+
+    /// Create a new repository
+    /// https://developer.github.com/v3/repos/#create
+    pub fn create(&self, repo: &RepoOptions) -> Result<Repo> {
+        let data = try!(serde_json::to_string(&repo));
+        self.github.post::<Repo>(&self.path(""), data.as_bytes())
     }
 
     /// list the authenticated users repositories


### PR DESCRIPTION
Hi,

I've added a create method on Repo to allow creation of new repositories as per [https://developer.github.com/v3/repos/#create](https://developer.github.com/v3/repos/#create).

I had to add a RepoOptions struct and accompanying Builder.

I've tried to keep everything as similar as possible to other code in rep.rs.in so hopefully there won't be too many issues with it.

I did have two queries.

1. Was there any reason the private field on `Repo` was commented out as ```private (keyword)```? I've added it back in for the moment.
2. I've added `team_id` on `RepoOptions` as an u32, since there is currently no implementation of teams in the library. Let me know if this is not the best option, happy to change it.

I'm more than happy to change any of this so please do let me know if you have any queries.

