### PR TITLE
Add "nightly" feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ build = "build.rs"
 
 [features]
 default = ["serde_codegen"]
-nightly = ["serde_macros"]
+nightly = ["serde_derive"]
 
 [dev-dependencies]
 env_logger = "0.3"
@@ -26,5 +26,5 @@ hyper = "0.9"
 url = "1.2"
 serde = "0.8"
 serde_json = "0.8"
-serde_macros = { version = "0.8", optional = true }
+serde_derive = { version = "0.8", optional = true }
 serializable_enum = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,15 @@ keywords = ["hyper", "github"]
 license = "MIT"
 build = "build.rs"
 
+[features]
+default = ["serde_codegen"]
+nightly = ["serde_macros"]
+
 [dev-dependencies]
 env_logger = "0.3"
 
 [build-dependencies]
-serde_codegen = "0.8"
+serde_codegen = { version = "0.8", optional = true }
 
 [dependencies]
 log = "0.3"
@@ -22,4 +26,5 @@ hyper = "0.9"
 url = "1.2"
 serde = "0.8"
 serde_json = "0.8"
+serde_macros = { version = "0.8", optional = true }
 serializable_enum = "0.3"

--- a/build.rs
+++ b/build.rs
@@ -1,13 +1,25 @@
-extern crate serde_codegen;
+#[cfg(not(feature = "serde_macros"))]
+mod inner {
+    extern crate serde_codegen;
 
-use std::env;
-use std::path::Path;
+    use std::env;
+    use std::path::Path;
+
+    pub fn main() {
+        let out_dir = env::var_os("OUT_DIR").unwrap();
+
+        let src = Path::new("src/rep.rs.in");
+        let dst = Path::new(&out_dir).join("rep.rs");
+
+        serde_codegen::expand(&src, &dst).unwrap();
+    }
+}
+
+#[cfg(feature = "serde_macros")]
+mod inner {
+    pub fn main() {}
+}
 
 fn main() {
-    let out_dir = env::var_os("OUT_DIR").unwrap();
-
-    let src = Path::new("src/rep.rs.in");
-    let dst = Path::new(&out_dir).join("rep.rs");
-
-    serde_codegen::expand(&src, &dst).unwrap();
+    inner::main();
 }

--- a/build.rs
+++ b/build.rs
@@ -1,25 +1,19 @@
-#[cfg(not(feature = "serde_macros"))]
-mod inner {
+#[cfg(feature = "serde_codegen")]
+fn main() {
     extern crate serde_codegen;
 
     use std::env;
     use std::path::Path;
 
-    pub fn main() {
-        let out_dir = env::var_os("OUT_DIR").unwrap();
+    let out_dir = env::var_os("OUT_DIR").unwrap();
 
-        let src = Path::new("src/rep.rs.in");
-        let dst = Path::new(&out_dir).join("rep.rs");
+    let src = Path::new("src/rep.rs.in");
+    let dst = Path::new(&out_dir).join("rep.rs");
 
-        serde_codegen::expand(&src, &dst).unwrap();
-    }
+    serde_codegen::expand(&src, &dst).unwrap();
 }
 
-#[cfg(feature = "serde_macros")]
-mod inner {
-    pub fn main() {}
-}
-
+#[cfg(not(feature = "serde_codegen"))]
 fn main() {
-    inner::main();
+    // Do nothing
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 //! Hubcaps provides a set of building blocks for interacting with the Github API
 
-#![cfg_attr(feature = "serde_derive", feature(rustc_macro))]
+#![cfg_attr(feature = "serde_derive", feature(proc_macro))]
 
 #[cfg(feature = "serde_derive")]
 #[macro_use]
@@ -218,8 +218,8 @@ impl<'a> Github<'a> {
 
                 let mut parsed = Url::parse(&url).unwrap();
                 parsed.query_pairs_mut()
-                      .append_pair("client_id", id)
-                      .append_pair("client_secret", secret);
+                    .append_pair("client_id", id)
+                    .append_pair("client_secret", secret);
                 self.client.request(method, parsed)
             }
             Credentials::None => self.client.request(method, &url),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,8 @@
 //! Hubcaps provides a set of building blocks for interacting with the Github API
 
+#![cfg_attr(feature = "serde_macros", feature(custom_derive, plugin))]
+#![cfg_attr(feature = "serde_macros", plugin(serde_macros))]
+
 #[macro_use]
 extern crate serializable_enum;
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,10 @@
 //! Hubcaps provides a set of building blocks for interacting with the Github API
 
-#![cfg_attr(feature = "serde_macros", feature(custom_derive, plugin))]
-#![cfg_attr(feature = "serde_macros", plugin(serde_macros))]
+#![cfg_attr(feature = "serde_derive", feature(rustc_macro))]
 
+#[cfg(feature = "serde_derive")]
+#[macro_use]
+extern crate serde_derive;
 #[macro_use]
 extern crate serializable_enum;
 #[macro_use]

--- a/src/rep.rs
+++ b/src/rep.rs
@@ -13,10 +13,10 @@ extern crate serializable_enum;
 extern crate serde;
 extern crate serde_json;
 
-#[cfg(feature = "serde_macros")]
+#[cfg(feature = "serde_derive")]
 include!("rep.rs.in");
 
-#[cfg(not(feature = "serde_macros"))]
+#[cfg(feature = "serde_codegen")]
 include!(concat!(env!("OUT_DIR"), "/rep.rs"));
 
 serializable_enum! {

--- a/src/rep.rs
+++ b/src/rep.rs
@@ -13,6 +13,10 @@ extern crate serializable_enum;
 extern crate serde;
 extern crate serde_json;
 
+#[cfg(feature = "serde_macros")]
+include!("rep.rs.in");
+
+#[cfg(not(feature = "serde_macros"))]
 include!(concat!(env!("OUT_DIR"), "/rep.rs"));
 
 serializable_enum! {


### PR DESCRIPTION
Due to serde-rs/quasi#54, it is impossible to include crates that use serde-codegen with quasi alongside crates that do not.

To solve this, I implement a "nightly" feature that, if enabled, compiles the serde code without codegen. This will only work on the nightly compiler.

Also, updates the code to use `serde_derive`, as `serde_macros` is now deprecated.

Should the travis config be updated to test this? It's the same code as tested by stable.
