### PR TITLE
Make repo description optional; it's sometimes null from github

### DIFF
--- a/src/rep.rs.in
+++ b/src/rep.rs.in
@@ -373,7 +373,7 @@ pub struct Repo {
     pub owner: User,
     pub name: String,
     pub full_name: String,
-    pub description: String,
+    pub description: Option<String>,
     pub private: bool,
     pub fork: bool,
     pub url: String,


### PR DESCRIPTION
Fixes #24.