### PR TITLE
Bump Hyper to support 0.10 as well.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ glob = "0.2.11"
 
 [dependencies]
 log = "0.3"
-hyper = "0.9"
+hyper = ">= 0.9.0, <0.11.0"
 url = "1.2"
 serde = "0.8"
 serde_json = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,8 @@ glob = "0.2.11"
 
 [dependencies]
 log = "0.3"
-hyper = ">= 0.9.0, <0.11.0"
+hyper = "0.10"
+hyper-openssl = "0.2"
 url = "1.2"
 serde = "0.8"
 serde_json = "0.8"


### PR DESCRIPTION
Updates the Hyper dependency to cover both the 0.9 and 0.10 series. (Straddling both avoids the need to make a major bump to this crate.)