### PR TITLE
Fix the order of IssuesItem::repo_tuple

### DIFF
--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -214,8 +214,7 @@ impl IssuesItem {
     /// returns a tuple of (repo owner name, repo name) associated with this issue
     pub fn repo_tuple(&self) -> (String, String) {
         let parsed = url::Url::parse(&self.repository_url).unwrap();
-        let mut path = parsed.path().split("/").collect::<Vec<_>>();
-        path.reverse();
+        let path = parsed.path().split("/").collect::<Vec<_>>();
         (path[0].to_owned(), path[1].to_owned())
     }
 }


### PR DESCRIPTION
Docs say that the method returns `(repo owner name, repo name)`, but the `Vec::reverse` call actually makes it `(repo name, repo owner name)`. This is inconsistent with the usual way GitHub refers to repositories.

This PR removes the erroneous `reverse` call.