### PR TITLE
Issue: make body an Option

### DIFF
--- a/src/issues/mod.rs
+++ b/src/issues/mod.rs
@@ -392,7 +392,7 @@ pub struct Issue {
     pub number: u64,
     pub state: String,
     pub title: String,
-    pub body: String,
+    pub body: Option<String>,
     pub user: User,
     pub labels: Vec<Label>,
     pub assignee: Option<User>,


### PR DESCRIPTION
A PR with absolutely no body causes errors with decoding, because GitHub sends a null body:

```
  pull_request: {
    url: https://api.github.com/repos/NixOS/nixpkgs/pulls/34454,
    html_url: https://github.com/NixOS/nixpkgs/pull/34454,
    diff_url: https://github.com/NixOS/nixpkgs/pull/34454.diff,
    patch_url: https://github.com/NixOS/nixpkgs/pull/34454.patch
  },
  body: null,
  closed_by: null
```