### PR TITLE
Add PullRequest::labels(), and make IssueLabels support being for an issue or a PR

### DIFF
--- a/src/issues/mod.rs
+++ b/src/issues/mod.rs
@@ -39,6 +39,23 @@ impl Default for State {
     }
 }
 
+/// enum representation of whether something is an issue or PR, for parts
+/// of the issues API that apply to both
+#[derive(Clone, Debug, PartialEq)]
+pub enum IssuesOrPull {
+    Issues,
+    Pull,
+}
+
+impl fmt::Display for IssuesOrPull {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            IssuesOrPull::Issues => "issues",
+            IssuesOrPull::Pull => "pull",
+        }.fmt(f)
+    }
+}
+
 /// Sort options available for github issues
 #[derive(Clone, Debug, PartialEq)]
 pub enum Sort {
@@ -71,12 +88,13 @@ pub struct IssueLabels<C: Clone + Connect> {
     github: Github<C>,
     owner: String,
     repo: String,
+    which: IssuesOrPull,
     number: u64,
 }
 
 impl<C: Clone + Connect> IssueLabels<C> {
     #[doc(hidden)]
-    pub fn new<O, R>(github: Github<C>, owner: O, repo: R, number: u64) -> Self
+    pub fn new<O, R>(github: Github<C>, owner: O, repo: R, which: IssuesOrPull, number: u64) -> Self
     where
         O: Into<String>,
         R: Into<String>,
@@ -85,14 +103,15 @@ impl<C: Clone + Connect> IssueLabels<C> {
             github: github,
             owner: owner.into(),
             repo: repo.into(),
+            which: which,
             number: number,
         }
     }
 
     fn path(&self, more: &str) -> String {
         format!(
-            "/repos/{}/{}/issues/{}/labels{}",
-            self.owner, self.repo, self.number, more
+            "/repos/{}/{}/{}/{}/labels{}",
+            self.owner, self.repo, self.which, self.number, more
         )
     }
 
@@ -164,6 +183,7 @@ impl<C: Clone + Connect> IssueRef<C> {
             self.github.clone(),
             self.owner.as_str(),
             self.repo.as_str(),
+            IssuesOrPull::Issues,
             self.number,
         )
     }

--- a/src/pulls/mod.rs
+++ b/src/pulls/mod.rs
@@ -11,7 +11,7 @@ use futures::future;
 use {unfold, Future, Github, SortDirection, Stream};
 use comments::Comments;
 use pull_commits::PullCommits;
-use issues::{Sort as IssueSort, State};
+use issues::{IssueLabels, IssuesOrPull, Sort as IssueSort, State};
 use review_comments::ReviewComments;
 use users::User;
 
@@ -85,6 +85,17 @@ impl<C: Clone + Connect> PullRequest<C> {
     /// Request a pull requests information
     pub fn get(&self) -> Future<Pull> {
         self.github.get(&self.path(""))
+    }
+
+    /// Return a reference to labels operations available for this pull request
+    pub fn labels(&self) -> IssueLabels<C> {
+        IssueLabels::new(
+            self.github.clone(),
+            self.owner.as_str(),
+            self.repo.as_str(),
+            IssuesOrPull::Pull,
+            self.number,
+        )
     }
 
     /// short hand for editing state = open


### PR DESCRIPTION
This implements support for part of the missing bits of the github API for PRs documented at https://developer.github.com/v3/pulls/#labels-assignees-and-milestones as being shared with the issues API.

Note that this contains an incompatible change to IssueLabels::new().

-----

I want this for dbaron/wgmeeting-github-ircbot#26.

So far I've tested that the code I want to use it for compiles, but I haven't actually tested that anything works yet.  Before I do that, I'd like to know your reaction to it.  Is this the right approach?  What should happen with the incompatible change?

(I could also go ahead and implement the other missing pieces as well if you think that's appropriate, although I wouldn't have an immediate way to test them.)