### PR TITLE
Improve contents interface

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,8 @@ serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
 error-chain = "0.12"
+base64 = "0.9"
+percent-encoding = "1"
 
 [dependencies.hyper-tls]
 optional = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,6 +81,8 @@ extern crate serde;
 extern crate serde_derive;
 extern crate serde_json;
 extern crate url;
+extern crate base64;
+extern crate percent_encoding;
 
 use std::fmt;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};


### PR DESCRIPTION
A new version hasn't been published with the last PR that added support to the contents API (#150), so this breaking change should be acceptable:

- Handles paths with spaces and other special characters.
- Handles decoding the file contents upon deserialization.
- Handles the case where we don't know what type of item will be returned using an enum variant. (Is it a file, symlink, or a submodule?)
- Returns a stream of directory items instead of a `Future<Vec<DirectoryItem>>`. We can use `.collect()` if the latter is needed.