### PR TITLE
hypers dependency is fixed. re-enable nightly builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,6 @@ matrix:
   - rust: nightly
   - rust: beta
   - rust: stable
-  allow_failures:
-    # hyper is not compiling on nightly https://github.com/hyperium/hyper/issues/1688
-    - rust: nightly
 
 script:
 - travis_wait cargo test


### PR DESCRIPTION
<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
2. This repository tries to stick with the community style conventions using [rustfmt](https://github.com/rust-lang-nursery/rustfmt#quick-start) with the *default* settings. If you have custom settings you may find that rustfmt
clutter the diff of your change with unrelated changes. Please apply formatting with `cargo  +nightly fmt` before submitting a pr.
-->

## What did you implement:

we had to turn of nightly builds because hyper wasn't compiling. that's fixed now

<!--
If this closes an open issue please replace xxx below with the issue number
-->

Closes: #xxx

#### How did you verify your change:

#### What (if anything) would need to be called out in the CHANGELOG for the next release: