### PR TITLE
Teams: create/update/edit teams + members

### DIFF
--- a/examples/teams.rs
+++ b/examples/teams.rs
@@ -1,6 +1,6 @@
-extern crate pretty_env_logger;
 extern crate futures;
 extern crate hubcaps;
+extern crate pretty_env_logger;
 extern crate tokio;
 
 use std::env;
@@ -8,6 +8,7 @@ use std::env;
 use futures::Stream;
 use tokio::runtime::Runtime;
 
+use hubcaps::teams::{TeamMemberOptions, TeamMemberRole, TeamOptions};
 use hubcaps::{Credentials, Github, Result};
 
 fn main() -> Result<()> {
@@ -19,22 +20,67 @@ fn main() -> Result<()> {
                 concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
                 Credentials::Token(token),
             );
+
+            let org = "eb6cb83a-cf75-4e88-a11a-ce117467d8ae";
+            let repo_name = "d18e3679-9830-40a9-8cf5-16602639b43e";
+
             println!("org teams");
-            rt.block_on(github.org("meetup").teams().iter().for_each(|team| {
+            rt.block_on(github.org(org).teams().iter().for_each(|team| {
                 println!("{:#?}", team);
                 Ok(())
-            }))?;
+            }))
+            .unwrap_or_else(|e| println!("error: {:#?}", e));
+
             println!("repo teams");
-            rt.block_on(
-                github
-                    .repo("meetup", "k8s-nginx-dogstats")
-                    .teams()
-                    .iter()
-                    .for_each(|team| {
-                        println!("{:#?}", team);
-                        Ok(())
-                    }),
-            )?;
+            rt.block_on(github.repo(org, repo_name).teams().iter().for_each(|team| {
+                println!("{:#?}", team);
+                Ok(())
+            }))
+            .unwrap_or_else(|e| println!("error: {:#?}", e));
+
+            let new_team = rt.block_on(github.org(org).teams().create(&TeamOptions {
+                name: String::from("hi"),
+                description: Some(String::from("there")),
+                permission: None,
+                privacy: Some(String::from("secret")),
+            }))?;
+            println!("Created team: {:#?}", new_team);
+
+            let team = github.org(org).teams().get(new_team.id);
+
+            let updated_team = rt.block_on(team.update(&TeamOptions {
+                name: String::from("hello"),
+                description: None,
+                permission: None,
+                privacy: None,
+            }))?;
+            println!("Updated team: {:#?}", updated_team);
+
+            println!(
+                "Adding grahamc to the team: {:#?}",
+                rt.block_on(team.add_user(
+                    "grahamc",
+                    TeamMemberOptions {
+                        role: TeamMemberRole::Member,
+                    }
+                ))
+            );
+
+            println!("members:");
+            rt.block_on(team.iter_members().for_each(|member| {
+                println!("{:#?}", member);
+                Ok(())
+            }))
+            .unwrap_or_else(|e| println!("error: {:#?}", e));
+
+            println!(
+                "Removing grahamc from the team: {:#?}",
+                rt.block_on(team.remove_user("grahamc"))
+            );
+
+            let deleted_team = rt.block_on(team.delete())?;
+            println!("Deleted team: {:#?}", deleted_team);
+
             Ok(())
         }
         _ => Err("example missing GITHUB_TOKEN".into()),


### PR DESCRIPTION
## What did you implement:

 - Create / update / delete teams
 - List / add / remove / update team members

#### How did you verify your change:

I ran the teams example.

#### What (if anything) would need to be called out in the CHANGELOG for the next release:
Support for creating, updating, deleting teams, plus listing, adding, removing, deleting team members.