### PR TITLE
Optional support for rustls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ features = ["tls","httpcache"]
 * improve contents API [#155](https://github.com/softprops/hubcaps/pull/155)
 * implement repository [contributors api](https://developer.github.com/v3/repos/#list-contributors) [#154](https://github.com/softprops/hubcaps/pull/154)
 * add release helper methods to get `latest` release and `release_by_tag` [#147](https://github.com/softprops/hubcaps/pull/147)
+* add optional [rustls](https://github.com/ctz/rustls) support
 
 
 # 0.4.10

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,9 +42,15 @@ percent-encoding = "1"
 optional = true
 version = "0.3"
 
+[dependencies.hyper-rustls]
+optional = true
+version = "0.14"
+
 [features]
 default = ["tls"]
 # enable tls
 tls = ["hyper-tls"]
+# enable rustls
+rustls = ["hyper-rustls"]
 # enable etag-based http_cache functionality
 httpcache = ["dirs"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,6 +96,8 @@ use hyper::header::{ACCEPT, AUTHORIZATION, ETAG, LINK, LOCATION, USER_AGENT};
 use hyper::{Body, Client, Method, Request, StatusCode, Uri};
 #[cfg(feature = "tls")]
 use hyper_tls::HttpsConnector;
+#[cfg(feature = "rustls")]
+use hyper_rustls::HttpsConnector;
 #[cfg(feature = "httpcache")]
 use hyperx::header::LinkValue;
 use hyperx::header::{qitem, Link, RelationType};
@@ -406,6 +408,15 @@ where
 }
 
 #[cfg(feature = "tls")]
+fn create_connector() -> HttpsConnector<HttpConnector> {
+    HttpsConnector::new(4).unwrap()
+}
+#[cfg(feature = "rustls")]
+fn create_connector() -> HttpsConnector<HttpConnector> {
+    HttpsConnector::new(4)
+}
+
+#[cfg(any(feature = "tls", feature = "rustls"))]
 impl Github<HttpsConnector<HttpConnector>> {
     pub fn new<A, C>(agent: A, credentials: C) -> Self
     where
@@ -421,7 +432,7 @@ impl Github<HttpsConnector<HttpConnector>> {
         A: Into<String>,
         C: Into<Option<Credentials>>,
     {
-        let connector = HttpsConnector::new(4).unwrap();
+        let connector = create_connector();
         let http = Client::builder().keep_alive(true).build(connector);
         #[cfg(feature = "httpcache")]
         {


### PR DESCRIPTION
## What did you implement:

Optional support for using `rustls` via `hyper-rustls` instead of `native-tls` via `hyper-tls`.

#### How did you verify your change:

It builds.

#### What (if anything) would need to be called out in the CHANGELOG for the next release:

I added a stub CHANGELOG message.