### PR TITLE
If base64 contains a line break, it will be InvalidBytes

### DIFF
--- a/src/content/mod.rs
+++ b/src/content/mod.rs
@@ -193,7 +193,9 @@ impl<'de> Deserialize<'de> for DecodedContents {
             where
                 E: de::Error,
             {
-                let decoded = base64::decode_config(v, base64::STANDARD).map_err(|e| match e {
+                //If base64 contains a line break, it will be InvalidBytes
+                let v = v.replace("\n", "");
+                let decoded = base64::decode_config(&v, base64::STANDARD).map_err(|e| match e {
                     base64::DecodeError::InvalidLength => {
                         E::invalid_length(v.len(), &"invalid base64 length")
                     }


### PR DESCRIPTION
## What did you implement:
A response from GutHub contains a line feed code.
But if you enter it directly into rust - base64 it will be InvalidBytes. So how about decoding after removing a line break?
<!--
If this closes an open issue please replace xxx below with the issue number
-->

