### PR TITLE
Replace hyper with reqwest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,10 +39,10 @@ base64 = "0.10"
 percent-encoding = "1"
 
 [features]
-default = ["tls"]
-# enable tls
-tls = ["reqwest/default-tls"]
+default = ["default-tls"]
+# enable native tls
+default-tls = ["reqwest/default-tls"]
 # enable rustls
-rustls = ["reqwest/rustls-tls"]
+rustls-tls = ["reqwest/rustls-tls"]
 # enable etag-based http_cache functionality
 httpcache = ["dirs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ jsonwebtoken = { version = "6", git = "https://github.com/Keats/jsonwebtoken", b
 mime = "0.3"
 log = "0.4"
 url = "1.7"
+reqwest = { version = "0.9.10", default-features = false }
 serde = { version = "1.0.84", features = ['derive'] }
 serde_derive = "1.0"
 serde_json = "1.0"
@@ -49,8 +50,8 @@ version = "0.16"
 [features]
 default = ["tls"]
 # enable tls
-tls = ["hyper-tls"]
+tls = ["hyper-tls", "reqwest/default-tls"]
 # enable rustls
-rustls = ["hyper-rustls"]
+rustls = ["hyper-rustls", "reqwest/rustls-tls"]
 # enable etag-based http_cache functionality
 httpcache = ["dirs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ futures = "0.1"
 http = "0.1"
 hyper = "0.12"
 hyperx = "0.13"
-jsonwebtoken = "5"
+jsonwebtoken = { version = "6", git = "https://github.com/Keats/jsonwebtoken", branch = "next" }
 mime = "0.3"
 log = "0.4"
 url = "1.7"
@@ -44,7 +44,7 @@ version = "0.3"
 
 [dependencies.hyper-rustls]
 optional = true
-version = "0.14"
+version = "0.16"
 
 [features]
 default = ["tls"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ tokio = "0.1"
 dirs = { version = "1.0", optional = true }
 futures = "0.1"
 http = "0.1"
-hyper = "0.12"
 hyperx = "0.13"
 jsonwebtoken = { version = "6", git = "https://github.com/Keats/jsonwebtoken", branch = "next" }
 mime = "0.3"
@@ -39,19 +38,11 @@ error-chain = "0.12"
 base64 = "0.10"
 percent-encoding = "1"
 
-[dependencies.hyper-tls]
-optional = true
-version = "0.3"
-
-[dependencies.hyper-rustls]
-optional = true
-version = "0.16"
-
 [features]
 default = ["tls"]
 # enable tls
-tls = ["hyper-tls", "reqwest/default-tls"]
+tls = ["reqwest/default-tls"]
 # enable rustls
-rustls = ["hyper-rustls", "reqwest/rustls-tls"]
+rustls = ["reqwest/rustls-tls"]
 # enable etag-based http_cache functionality
 httpcache = ["dirs"]

--- a/examples/assignees.rs
+++ b/examples/assignees.rs
@@ -12,7 +12,7 @@ fn main() -> Result<()> {
             let github = Github::new(
                 concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
                 Credentials::Token(token),
-            );
+            )?;
             let pull = rt.block_on(
                 github
                     .repo("softprops", "hubcaps")

--- a/examples/branches.rs
+++ b/examples/branches.rs
@@ -14,7 +14,7 @@ fn main() -> Result<()> {
             let github = Github::new(
                 concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
                 Credentials::Token(token),
-            );
+            )?;
 
             if let Err(err) = rt.block_on(
                 github

--- a/examples/checks.rs
+++ b/examples/checks.rs
@@ -33,7 +33,7 @@ fn main() -> Result<()> {
     File::open(&key_file)?.read_to_end(&mut key)?;
     let cred = JWTCredentials::new(app_id.parse().expect("Bad GH_APP_ID"), key)?;
 
-    let mut github = Github::new(USER_AGENT, Credentials::JWT(cred.clone()));
+    let mut github = Github::new(USER_AGENT, Credentials::JWT(cred.clone()))?;
     let installation = rt
         .block_on(
             github

--- a/examples/comments.rs
+++ b/examples/comments.rs
@@ -12,7 +12,7 @@ fn main() -> Result<()> {
     match env::var("GITHUB_TOKEN").ok() {
         Some(token) => {
             let mut rt = Runtime::new()?;
-            let github = Github::new(USER_AGENT, Credentials::Token(token));
+            let github = Github::new(USER_AGENT, Credentials::Token(token))?;
 
             let issue = github.repo("softprops", "hubcat").issues().get(1);
             let f = issue.comments().create(&CommentOptions {

--- a/examples/conditional_requests.rs
+++ b/examples/conditional_requests.rs
@@ -14,7 +14,7 @@ fn main() -> Result<()> {
 
     #[cfg(not(feature = "httpcache"))]
     {
-        println!("rerun this example with `cargo run --no-default-features --features tls,httpcache --example conditional_requests`");
+        println!("rerun this example with `cargo run --no-default-features --features default-tls,httpcache --example conditional_requests`");
         Ok(())
     }
 

--- a/examples/conditional_requests.rs
+++ b/examples/conditional_requests.rs
@@ -1,7 +1,6 @@
 #[cfg(feature = "httpcache")]
 use {
-    hyper::Client,
-    hyper_tls::HttpsConnector,
+    reqwest::r#async::Client,
     tokio::runtime::Runtime,
 };
 
@@ -25,7 +24,7 @@ fn main() -> Result<()> {
 
         let host = "https://api.github.com";
         let agent = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"));
-        let client = Client::builder().build(HttpsConnector::new(4).unwrap());
+        let client = Client::builder().build()?;
         let http_cache = HttpCache::in_home_dir();
         let github = Github::custom(host, agent, None, client, http_cache);
 

--- a/examples/content.rs
+++ b/examples/content.rs
@@ -14,7 +14,7 @@ fn main() -> Result<()> {
             let github = Github::new(
                 concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
                 Credentials::Token(token),
-            );
+            )?;
 
             let repo = github.repo("softprops", "hubcaps");
 

--- a/examples/deployments.rs
+++ b/examples/deployments.rs
@@ -11,7 +11,7 @@ fn main() -> Result<()> {
             let github = Github::new(
                 concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
                 Credentials::Token(token),
-            );
+            )?;
             let repo = github.repo("softprops", "hubcaps");
             let deployments = repo.deployments();
             // let deploy = deployments.create(&DeploymentOptions::builder("master")

--- a/examples/gists.rs
+++ b/examples/gists.rs
@@ -12,7 +12,7 @@ fn main() -> Result<()> {
             let github = Github::new(
                 concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
                 Credentials::Token(token),
-            );
+            )?;
             for gist in rt.block_on(github.gists().list(&Default::default()))? {
                 println!("{:#?}", gist)
             }

--- a/examples/gists_create.rs
+++ b/examples/gists_create.rs
@@ -14,7 +14,7 @@ fn main() -> Result<()> {
             let github = Github::new(
                 concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
                 Credentials::Token(token),
-            );
+            )?;
 
             // create new gist
             let mut files = HashMap::new();

--- a/examples/git.rs
+++ b/examples/git.rs
@@ -12,7 +12,7 @@ fn main() -> Result<()> {
             let github = Github::new(
                 concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
                 Credentials::Token(token),
-            );
+            )?;
             if let Some(file) = rt
                 .block_on(
                     github

--- a/examples/hooks.rs
+++ b/examples/hooks.rs
@@ -13,7 +13,7 @@ fn main() -> Result<()> {
             let github = Github::new(
                 concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
                 Credentials::Token(token),
-            );
+            )?;
             let repo = github.repo("softprops", "hubcaps");
             let hook = rt.block_on(
                 repo.hooks().create(

--- a/examples/issues.rs
+++ b/examples/issues.rs
@@ -14,7 +14,7 @@ fn main() -> Result<()> {
             let github = Github::new(
                 concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
                 Credentials::Token(token),
-            );
+            )?;
             rt.block_on(
                 github
                     .repo("matthiasbeyer", "imag")

--- a/examples/labels.rs
+++ b/examples/labels.rs
@@ -13,7 +13,7 @@ fn main() -> Result<()> {
             let github = Github::new(
                 concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
                 Credentials::Token(token),
-            );
+            )?;
             // add labels associated with a pull
             println!(
                 "{:#?}",

--- a/examples/notifications.rs
+++ b/examples/notifications.rs
@@ -13,7 +13,7 @@ fn main() -> Result<()> {
             let github = Github::new(
                 concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
                 Credentials::Token(token),
-            );
+            )?;
 
             let opts = ThreadListOptions::builder().all(true).build();
             for thread in rt.block_on(github.activity().notifications().list(&opts))? {

--- a/examples/orgs.rs
+++ b/examples/orgs.rs
@@ -13,7 +13,7 @@ fn main() -> Result<()> {
             let github = Github::new(
                 concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
                 Credentials::Token(token),
-            );
+            )?;
 
             let options = OrganizationRepoListOptions::builder()
                 .repo_type(OrgRepoType::Forks)

--- a/examples/pull_files.rs
+++ b/examples/pull_files.rs
@@ -12,7 +12,7 @@ fn main() -> Result<()> {
             let github = Github::new(
                 concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
                 Credentials::Token(token),
-            );
+            )?;
             for diff in rt.block_on(github.repo("rust-lang", "rust").pulls().get(49536).files())? {
                 println!("{:#?}", diff);
             }

--- a/examples/pulls.rs
+++ b/examples/pulls.rs
@@ -13,7 +13,7 @@ fn main() -> Result<()> {
             let github = Github::new(
                 concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
                 Credentials::Token(token),
-            );
+            )?;
             let repo = github.repo("softprops", "hubcat");
             let pulls = repo.pulls();
             rt.block_on(pulls.iter(&Default::default()).for_each(|pull| {

--- a/examples/rate_limit.rs
+++ b/examples/rate_limit.rs
@@ -8,7 +8,7 @@ fn main() -> Result<()> {
     let github = Github::new(
         concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
         None,
-    );
+    )?;
     let status = rt.block_on(github.rate_limit().get())?;
     println!("{:#?}", status);
     Ok(())

--- a/examples/redir.rs
+++ b/examples/redir.rs
@@ -12,7 +12,7 @@ fn main() -> Result<()> {
             let github = Github::new(
                 concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
                 Credentials::Token(token),
-            );
+            )?;
             rt.block_on(github.activity().stars().star("rust-lang", "log"))?;
             Ok(())
         }

--- a/examples/releases.rs
+++ b/examples/releases.rs
@@ -12,7 +12,7 @@ fn main() -> Result<()> {
             let github = Github::new(
                 concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
                 Credentials::Token(token),
-            );
+            )?;
             let owner = "octokit";
             let repo = "rest.js";
 

--- a/examples/repos.rs
+++ b/examples/repos.rs
@@ -13,7 +13,7 @@ fn main() -> Result<()> {
             let github = Github::new(
                 concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
                 Credentials::Token(token),
-            );
+            )?;
             let handle = rt.executor();
             rt.block_on(
                 github

--- a/examples/search_issues.rs
+++ b/examples/search_issues.rs
@@ -14,7 +14,7 @@ fn main() -> Result<()> {
             let github = Github::new(
                 concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
                 Credentials::Token(token),
-            );
+            )?;
             println!("issue search results");
             // https://developer.github.com/v3/search/#parameters-3
             rt.block_on(

--- a/examples/search_repos.rs
+++ b/examples/search_repos.rs
@@ -14,7 +14,7 @@ fn main() -> Result<()> {
             let github = Github::new(
                 concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
                 Credentials::Token(token),
-            );
+            )?;
             println!("repo search results");
             // https://developer.github.com/v3/search/#parameters
             rt.block_on(

--- a/examples/stars.rs
+++ b/examples/stars.rs
@@ -13,7 +13,7 @@ fn main() -> Result<()> {
             let github = Github::new(
                 concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
                 Credentials::Token(token),
-            );
+            )?;
             let stars = github.activity().stars();
             let f = stars
                 .star("softprops", "hubcaps")

--- a/examples/teams.rs
+++ b/examples/teams.rs
@@ -14,7 +14,7 @@ fn main() -> Result<()> {
             let github = Github::new(
                 concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
                 Credentials::Token(token),
-            );
+            )?;
 
             let org = "eb6cb83a-cf75-4e88-a11a-ce117467d8ae";
             let repo_name = "d18e3679-9830-40a9-8cf5-16602639b43e";

--- a/examples/traffic.rs
+++ b/examples/traffic.rs
@@ -13,7 +13,7 @@ fn main() -> Result<()> {
             let github = Github::new(
                 concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
                 Credentials::Token(token),
-            );
+            )?;
             let owner = "softprops";
             let repo = "hubcaps";
 

--- a/examples/users.rs
+++ b/examples/users.rs
@@ -12,7 +12,7 @@ fn main() -> Result<()> {
             let github = Github::new(
                 concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
                 Credentials::Token(token),
-            );
+            )?;
             match rt.block_on(github.users().authenticated()) {
                 Ok(me) => println!("{:#?}", me),
                 Err(err) => println!("err {:#?}", err),

--- a/examples/watching.rs
+++ b/examples/watching.rs
@@ -12,7 +12,7 @@ fn main() -> Result<()> {
     let github = Github::new(
         concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
         Credentials::Token(token),
-    );
+    )?;
 
     println!("watched repos");
     rt.block_on(github.activity().watching().iter().for_each(|repo| {

--- a/src/activity.rs
+++ b/src/activity.rs
@@ -1,38 +1,32 @@
 //! Activity interface
-
-use hyper::client::connect::Connect;
-
 use crate::notifications::Notifications;
 use crate::stars::Stars;
 use crate::watching::Watching;
 use crate::Github;
 
-pub struct Activity<C>
-where
-    C: Clone + Connect + 'static,
-{
-    github: Github<C>,
+pub struct Activity {
+    github: Github,
 }
 
-impl<C: Clone + Connect + 'static> Activity<C> {
+impl Activity {
     #[doc(hidden)]
-    pub fn new(github: Github<C>) -> Self {
+    pub fn new(github: Github) -> Self {
         Self { github }
     }
 
     /// Return a reference to notifications operations
-    pub fn notifications(&self) -> Notifications<C> {
+    pub fn notifications(&self) -> Notifications {
         Notifications::new(self.github.clone())
     }
 
     /// return a reference to starring operations
-    pub fn stars(&self) -> Stars<C> {
+    pub fn stars(&self) -> Stars {
         Stars::new(self.github.clone())
     }
 
     /// Return a reference to watching operations
     /// https://developer.github.com/v3/activity/watching
-    pub fn watching(&self) -> Watching<C> {
+    pub fn watching(&self) -> Watching {
         Watching::new(self.github.clone())
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,22 +1,15 @@
 //! Labels interface
-use hyper::client::connect::Connect;
 use serde::Deserialize;
 
 use self::super::{AuthenticationConstraint, Future, Github, MediaType};
 
-pub struct App<C>
-where
-    C: Clone + Connect + 'static,
-{
-    github: Github<C>,
+pub struct App {
+    github: Github,
 }
 
-impl<C> App<C>
-where
-    C: Clone + Connect + 'static,
-{
+impl App {
     #[doc(hidden)]
-    pub(crate) fn new(github: Github<C>) -> Self {
+    pub(crate) fn new(github: Github) -> Self {
         App { github: github }
     }
 

--- a/src/branches.rs
+++ b/src/branches.rs
@@ -2,24 +2,20 @@
 //!
 //! For more information, visit the official
 //! [Github docs](https://developer.github.com/v3/repos/branches/)
-use hyper::client::connect::Connect;
 use serde::{Deserialize, Serialize};
 
 use crate::{Future, Github, Stream};
 
 /// reference to gists associated with a github user
-pub struct Branches<C>
-where
-    C: Clone + Connect + 'static,
-{
-    github: Github<C>,
+pub struct Branches {
+    github: Github,
     owner: String,
     repo: String,
 }
 
-impl<C: Clone + Connect + 'static> Branches<C> {
+impl Branches {
     #[doc(hidden)]
-    pub fn new<U, R>(github: Github<C>, owner: U, repo: R) -> Self
+    pub fn new<U, R>(github: Github, owner: U, repo: R) -> Self
     where
         U: Into<String>,
         R: Into<String>,

--- a/src/checks.rs
+++ b/src/checks.rs
@@ -1,26 +1,19 @@
 //! Checks interface
 // see: https://developer.github.com/v3/checks/suites/
 use futures::IntoFuture;
-use hyper::client::connect::Connect;
 use serde::{Deserialize, Serialize};
 
 use self::super::{AuthenticationConstraint, Future, Github, MediaType};
 
-pub struct CheckRuns<C>
-where
-    C: Clone + Connect + 'static,
-{
-    github: Github<C>,
+pub struct CheckRuns {
+    github: Github,
     owner: String,
     repo: String,
 }
 
-impl<'a, C> CheckRuns<C>
-where
-    C: Clone + Connect + 'static,
-{
+impl<'a> CheckRuns {
     #[doc(hidden)]
-    pub(crate) fn new<O, R>(github: Github<C>, owner: O, repo: R) -> Self
+    pub(crate) fn new<O, R>(github: Github, owner: O, repo: R) -> Self
     where
         O: Into<String>,
         R: Into<String>,

--- a/src/comments.rs
+++ b/src/comments.rs
@@ -1,7 +1,6 @@
 //! Comments interface
 use std::collections::HashMap;
 
-use hyper::client::connect::Connect;
 use url::form_urlencoded;
 use serde::{Deserialize, Serialize};
 
@@ -9,19 +8,16 @@ use crate::users::User;
 use crate::{Future, Github};
 
 /// A structure for interfacing with a issue comments
-pub struct Comments<C>
-where
-    C: Clone + Connect + 'static,
-{
-    github: Github<C>,
+pub struct Comments {
+    github: Github,
     owner: String,
     repo: String,
     number: u64,
 }
 
-impl<C: Clone + Connect + 'static> Comments<C> {
+impl Comments {
     #[doc(hidden)]
-    pub fn new<O, R>(github: Github<C>, owner: O, repo: R, number: u64) -> Self
+    pub fn new<O, R>(github: Github, owner: O, repo: R, number: u64) -> Self
     where
         O: Into<String>,
         R: Into<String>,

--- a/src/content.rs
+++ b/src/content.rs
@@ -2,7 +2,6 @@
 use std::fmt;
 use std::ops;
 
-use hyper::client::connect::Connect;
 use percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
 use serde::Deserialize;
 use serde::de::{self, Visitor};
@@ -10,18 +9,15 @@ use serde::de::{self, Visitor};
 use crate::{Future, Github, Stream};
 
 /// Provides access to the content information for a repository
-pub struct Content<C>
-where
-    C: Clone + Connect + 'static,
-{
-    github: Github<C>,
+pub struct Content {
+    github: Github,
     owner: String,
     repo: String,
 }
 
-impl<C: Clone + Connect + 'static> Content<C> {
+impl Content {
     #[doc(hidden)]
-    pub fn new<O, R>(github: Github<C>, owner: O, repo: R) -> Self
+    pub fn new<O, R>(github: Github, owner: O, repo: R) -> Self
     where
         O: Into<String>,
         R: Into<String>,

--- a/src/deployments.rs
+++ b/src/deployments.rs
@@ -1,7 +1,6 @@
 //! Deployments interface
 use std::collections::HashMap;
 
-use hyper::client::connect::Connect;
 use url::form_urlencoded;
 use serde::{Deserialize, Serialize};
 
@@ -10,29 +9,23 @@ use crate::users::User;
 use crate::{Future, Github};
 
 /// Interface for repository deployments
-pub struct Deployments<C>
-where
-    C: Clone + Connect + 'static,
-{
-    github: Github<C>,
+pub struct Deployments {
+    github: Github,
     owner: String,
     repo: String,
 }
 
 /// Interface for deployment statuses
-pub struct DeploymentStatuses<C>
-where
-    C: Clone + Connect + 'static,
-{
-    github: Github<C>,
+pub struct DeploymentStatuses {
+    github: Github,
     owner: String,
     repo: String,
     id: u64,
 }
 
-impl<C: Clone + Connect + 'static> DeploymentStatuses<C> {
+impl DeploymentStatuses {
     #[doc(hidden)]
-    pub fn new<O, R>(github: Github<C>, owner: O, repo: R, id: u64) -> Self
+    pub fn new<O, R>(github: Github, owner: O, repo: R, id: u64) -> Self
     where
         O: Into<String>,
         R: Into<String>,
@@ -64,9 +57,9 @@ impl<C: Clone + Connect + 'static> DeploymentStatuses<C> {
     }
 }
 
-impl<C: Clone + Connect + 'static> Deployments<C> {
+impl Deployments {
     /// Create a new deployments instance
-    pub fn new<O, R>(github: Github<C>, owner: O, repo: R) -> Deployments<C>
+    pub fn new<O, R>(github: Github, owner: O, repo: R) -> Deployments
     where
         O: Into<String>,
         R: Into<String>,
@@ -97,7 +90,7 @@ impl<C: Clone + Connect + 'static> Deployments<C> {
     }
 
     /// get a reference to the statuses api for a give deployment
-    pub fn statuses(&self, id: u64) -> DeploymentStatuses<C> {
+    pub fn statuses(&self, id: u64) -> DeploymentStatuses {
         DeploymentStatuses::new(
             self.github.clone(),
             self.owner.as_str(),

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -3,10 +3,7 @@ use std::io::Error as IoError;
 use std::time::Duration;
 
 use error_chain::*;
-use http::uri::InvalidUri;
-use http::Error as HttpError;
-use hyper::Error as HyperError;
-use hyper::StatusCode;
+use http::StatusCode;
 use reqwest::Error as ReqwestError;
 use serde::Deserialize;
 use serde_json::error::Error as SerdeError;
@@ -33,12 +30,9 @@ error_chain! {
     }
     foreign_links {
         Codec(SerdeError);
-        Http(HttpError);
-        Hyper(HyperError);
         Reqwest(ReqwestError);
         Url(ParseError);
         IO(IoError);
-        URI(InvalidUri);
         JWT(JWTError);
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -7,8 +7,10 @@ use http::uri::InvalidUri;
 use http::Error as HttpError;
 use hyper::Error as HyperError;
 use hyper::StatusCode;
+use reqwest::Error as ReqwestError;
 use serde::Deserialize;
 use serde_json::error::Error as SerdeError;
+use url::ParseError;
 
 use crate::jwt::errors::Error as JWTError;
 
@@ -33,6 +35,8 @@ error_chain! {
         Codec(SerdeError);
         Http(HttpError);
         Hyper(HyperError);
+        Reqwest(ReqwestError);
+        Url(ParseError);
         IO(IoError);
         URI(InvalidUri);
         JWT(JWTError);

--- a/src/gists.rs
+++ b/src/gists.rs
@@ -2,7 +2,6 @@
 use std::collections::HashMap;
 use std::hash::Hash;
 
-use hyper::client::connect::Connect;
 use url::form_urlencoded;
 use serde::{Deserialize, Serialize};
 
@@ -10,17 +9,14 @@ use crate::users::User;
 use crate::{Future, Github};
 
 /// reference to gists associated with a github user
-pub struct UserGists<C>
-where
-    C: Clone + Connect + 'static,
-{
-    github: Github<C>,
+pub struct UserGists {
+    github: Github,
     owner: String,
 }
 
-impl<C: Clone + Connect + 'static> UserGists<C> {
+impl UserGists {
     #[doc(hidden)]
-    pub fn new<O>(github: Github<C>, owner: O) -> Self
+    pub fn new<O>(github: Github, owner: O) -> Self
     where
         O: Into<String>,
     {
@@ -39,16 +35,13 @@ impl<C: Clone + Connect + 'static> UserGists<C> {
     }
 }
 
-pub struct Gists<C>
-where
-    C: Clone + Connect + 'static,
-{
-    github: Github<C>,
+pub struct Gists {
+    github: Github,
 }
 
-impl<C: Clone + Connect + 'static> Gists<C> {
+impl Gists {
     #[doc(hidden)]
-    pub fn new(github: Github<C>) -> Self {
+    pub fn new(github: Github) -> Self {
         Self { github }
     }
 

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,25 +1,21 @@
 //! Git interface
 
 // Third party
-use hyper::client::connect::Connect;
 use serde::Deserialize;
 
 // Ours
 use crate::{Future, Github};
 
 /// reference to git operations associated with a github repo
-pub struct Git<C>
-where
-    C: Clone + Connect + 'static,
-{
-    github: Github<C>,
+pub struct Git {
+    github: Github,
     owner: String,
     repo: String,
 }
 
-impl<C: Clone + Connect + 'static> Git<C> {
+impl Git {
     #[doc(hidden)]
-    pub fn new<O, R>(github: Github<C>, owner: O, repo: R) -> Self
+    pub fn new<O, R>(github: Github, owner: O, repo: R) -> Self
     where
         O: Into<String>,
         R: Into<String>,

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -4,7 +4,6 @@
 use std::collections::BTreeMap;
 use std::fmt;
 
-use hyper::client::connect::Connect;
 use serde::{Deserialize, Serialize};
 
 use crate::{Future, Github};
@@ -38,18 +37,15 @@ impl fmt::Display for WebHookContentType {
 }
 
 /// Interface for managing repository hooks
-pub struct Hooks<C>
-where
-    C: Clone + Connect + 'static,
-{
-    github: Github<C>,
+pub struct Hooks {
+    github: Github,
     owner: String,
     repo: String,
 }
 
-impl<C: Clone + Connect + 'static> Hooks<C> {
+impl Hooks {
     #[doc(hidden)]
-    pub fn new<O, R>(github: Github<C>, owner: O, repo: R) -> Self
+    pub fn new<O, R>(github: Github, owner: O, repo: R) -> Self
     where
         O: Into<String>,
         R: Into<String>,

--- a/src/http_cache.rs
+++ b/src/http_cache.rs
@@ -7,7 +7,7 @@ use std::hash::{Hash, Hasher};
 use std::io;
 use std::path::{Path, PathBuf};
 
-use hyper::Uri;
+use http::Uri;
 use log::trace;
 
 use crate::{Error, Result};

--- a/src/issues.rs
+++ b/src/issues.rs
@@ -2,7 +2,6 @@
 use std::collections::HashMap;
 use std::fmt;
 
-use hyper::client::connect::Connect;
 use url::form_urlencoded;
 use serde::{Deserialize, Serialize};
 
@@ -68,16 +67,16 @@ impl Default for Sort {
 }
 
 /// Provides access to assignee operations available for an individual issue
-pub struct IssueAssignees<C: Clone + Connect + 'static> {
-    github: Github<C>,
+pub struct IssueAssignees {
+    github: Github,
     owner: String,
     repo: String,
     number: u64,
 }
 
-impl<C: Clone + Connect + 'static> IssueAssignees<C> {
+impl IssueAssignees {
     #[doc(hidden)]
-    pub fn new<O, R>(github: Github<C>, owner: O, repo: R, number: u64) -> Self
+    pub fn new<O, R>(github: Github, owner: O, repo: R, number: u64) -> Self
     where
         O: Into<String>,
         R: Into<String>,
@@ -104,16 +103,16 @@ impl<C: Clone + Connect + 'static> IssueAssignees<C> {
 }
 
 /// Provides access to label operations available for an individual issue
-pub struct IssueLabels<C: Clone + Connect + 'static> {
-    github: Github<C>,
+pub struct IssueLabels {
+    github: Github,
     owner: String,
     repo: String,
     number: u64,
 }
 
-impl<C: Clone + Connect + 'static> IssueLabels<C> {
+impl IssueLabels {
     #[doc(hidden)]
-    pub fn new<O, R>(github: Github<C>, owner: O, repo: R, number: u64) -> Self
+    pub fn new<O, R>(github: Github, owner: O, repo: R, number: u64) -> Self
     where
         O: Into<String>,
         R: Into<String>,
@@ -160,19 +159,16 @@ impl<C: Clone + Connect + 'static> IssueLabels<C> {
 
 /// Provides access to operations available for a single issue
 /// Typically accessed from `github.repo(.., ..).issues().get(number)`
-pub struct IssueRef<C>
-where
-    C: Clone + Connect + 'static,
-{
-    github: Github<C>,
+pub struct IssueRef {
+    github: Github,
     owner: String,
     repo: String,
     number: u64,
 }
 
-impl<C: Clone + Connect + 'static> IssueRef<C> {
+impl IssueRef {
     #[doc(hidden)]
-    pub fn new<O, R>(github: Github<C>, owner: O, repo: R, number: u64) -> Self
+    pub fn new<O, R>(github: Github, owner: O, repo: R, number: u64) -> Self
     where
         O: Into<String>,
         R: Into<String>,
@@ -198,7 +194,7 @@ impl<C: Clone + Connect + 'static> IssueRef<C> {
     }
 
     /// Return a reference to labels operations available for this issue
-    pub fn labels(&self) -> IssueLabels<C> {
+    pub fn labels(&self) -> IssueLabels {
         IssueLabels::new(
             self.github.clone(),
             self.owner.as_str(),
@@ -208,7 +204,7 @@ impl<C: Clone + Connect + 'static> IssueRef<C> {
     }
 
     /// Return a reference to assignee operations available for this issue
-    pub fn assignees(&self) -> IssueAssignees<C> {
+    pub fn assignees(&self) -> IssueAssignees {
         IssueAssignees::new(
             self.github.clone(),
             self.owner.as_str(),
@@ -223,7 +219,7 @@ impl<C: Clone + Connect + 'static> IssueRef<C> {
     }
 
     /// Return a reference to comment operations available for this issue
-    pub fn comments(&self) -> Comments<C> {
+    pub fn comments(&self) -> Comments {
         Comments::new(
             self.github.clone(),
             self.owner.clone(),
@@ -235,18 +231,15 @@ impl<C: Clone + Connect + 'static> IssueRef<C> {
 
 /// Provides access to operations available for a repository issues
 /// Typically accessed via `github.repo(..., ...).issues()`
-pub struct Issues<C>
-where
-    C: Clone + Connect + 'static,
-{
-    github: Github<C>,
+pub struct Issues {
+    github: Github,
     owner: String,
     repo: String,
 }
 
-impl<C: Clone + Connect + 'static> Issues<C> {
+impl Issues {
     /// create a new instance of a github repo issue ref
-    pub fn new<O, R>(github: Github<C>, owner: O, repo: R) -> Self
+    pub fn new<O, R>(github: Github, owner: O, repo: R) -> Self
     where
         O: Into<String>,
         R: Into<String>,
@@ -262,7 +255,7 @@ impl<C: Clone + Connect + 'static> Issues<C> {
         format!("/repos/{}/{}/issues{}", self.owner, self.repo, more)
     }
 
-    pub fn get(&self, number: u64) -> IssueRef<C> {
+    pub fn get(&self, number: u64) -> IssueRef {
         IssueRef::new(
             self.github.clone(),
             self.owner.as_str(),

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -2,23 +2,19 @@
 //!
 //! This [this document](https://developer.github.com/guides/managing-deploy-keys/)
 //! for motivation and use
-use hyper::client::connect::Connect;
 use serde::{Deserialize, Serialize};
 
 use crate::{Future, Github};
 
-pub struct Keys<C>
-where
-    C: Clone + Connect + 'static,
-{
-    github: Github<C>,
+pub struct Keys {
+    github: Github,
     owner: String,
     repo: String,
 }
 
-impl<C: Clone + Connect + 'static> Keys<C> {
+impl Keys {
     #[doc(hidden)]
-    pub fn new<O, R>(github: Github<C>, owner: O, repo: R) -> Self
+    pub fn new<O, R>(github: Github, owner: O, repo: R) -> Self
     where
         O: Into<String>,
         R: Into<String>,

--- a/src/labels.rs
+++ b/src/labels.rs
@@ -1,21 +1,17 @@
 //! Labels interface
-use hyper::client::connect::Connect;
 use serde::{Deserialize, Serialize};
 
 use crate::{Future, Github, Stream};
 
-pub struct Labels<C>
-where
-    C: Clone + Connect + 'static,
-{
-    github: Github<C>,
+pub struct Labels {
+    github: Github,
     owner: String,
     repo: String,
 }
 
-impl<C: Clone + Connect + 'static> Labels<C> {
+impl Labels {
     #[doc(hidden)]
-    pub fn new<O, R>(github: Github<C>, owner: O, repo: R) -> Self
+    pub fn new<O, R>(github: Github, owner: O, repo: R) -> Self
     where
         O: Into<String>,
         R: Into<String>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -400,7 +400,6 @@ pub struct Github {
     http_cache: BoxedHttpCache,
 }
 
-#[cfg(any(feature = "tls", feature = "rustls"))]
 impl Github {
     pub fn new<A, C>(agent: A, credentials: C) -> Result<Self>
     where
@@ -426,9 +425,7 @@ impl Github {
             Ok(Self::custom(host, agent, credentials, http))
         }
     }
-}
 
-impl Github {
     #[cfg(feature = "httpcache")]
     pub fn custom<H, A, CR>(
         host: H,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,8 +91,8 @@ use futures::{future, stream, Future as StdFuture, IntoFuture, Stream as StdStre
 use http::header::{HeaderMap, HeaderValue};
 use http::{Method, StatusCode};
 #[cfg(feature = "httpcache")]
-use hyper::header::IF_NONE_MATCH;
-use hyper::header::{ACCEPT, AUTHORIZATION, ETAG, LINK, LOCATION, USER_AGENT};
+use http::header::IF_NONE_MATCH;
+use http::header::{ACCEPT, AUTHORIZATION, ETAG, LINK, LOCATION, USER_AGENT};
 #[cfg(feature = "httpcache")]
 use hyperx::header::LinkValue;
 use hyperx::header::{qitem, Link, RelationType};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,7 @@
 //! [dependencies.hubcaps]
 //!  version = "..."
 //!  default-features = false
-//!  features = ["tls","httpcache"]
+//!  features = ["default-tls","httpcache"]
 //! ```
 //!
 //! Then use the `Github::custom` constructor to provide a cache implementation. See

--- a/src/notifications.rs
+++ b/src/notifications.rs
@@ -1,7 +1,6 @@
 //! Notifications interface
 use std::collections::HashMap;
 
-use hyper::client::connect::Connect;
 use url::form_urlencoded;
 use serde::Deserialize;
 
@@ -12,16 +11,13 @@ use crate::Github;
 /// Provides access to notifications.
 /// See the [github docs](https://developer.github.com/v3/activity/notifications/)
 /// for more information.
-pub struct Notifications<C>
-where
-    C: Clone + Connect + 'static,
-{
-    github: Github<C>,
+pub struct Notifications {
+    github: Github,
 }
 
-impl<C: Clone + Connect + 'static> Notifications<C> {
+impl Notifications {
     #[doc(hidden)]
-    pub fn new(github: Github<C>) -> Self {
+    pub fn new(github: Github) -> Self {
         Self { github }
     }
 

--- a/src/organizations.rs
+++ b/src/organizations.rs
@@ -1,5 +1,4 @@
 //! Organizations interface
-use hyper::client::connect::Connect;
 use serde::Deserialize;
 
 use crate::repositories::OrgRepositories;
@@ -7,17 +6,14 @@ use crate::teams::OrgTeams;
 use crate::{Future, Github};
 
 /// Provides access to label operations available for an individual organization
-pub struct Organization<C>
-where
-    C: Clone + Connect + 'static,
-{
-    github: Github<C>,
+pub struct Organization {
+    github: Github,
     org: String,
 }
 
-impl<C: Clone + Connect + 'static> Organization<C> {
+impl Organization {
     #[doc(hidden)]
-    pub fn new<O>(github: Github<C>, org: O) -> Self
+    pub fn new<O>(github: Github, org: O) -> Self
     where
         O: Into<String>,
     {
@@ -28,26 +24,23 @@ impl<C: Clone + Connect + 'static> Organization<C> {
     }
 
     /// returns a reference to an interface for team operations
-    pub fn teams(&self) -> OrgTeams<C> {
+    pub fn teams(&self) -> OrgTeams {
         OrgTeams::new(self.github.clone(), self.org.clone())
     }
 
     /// returns a reference to an interface for repo operations
-    pub fn repos(&self) -> OrgRepositories<C> {
+    pub fn repos(&self) -> OrgRepositories {
         OrgRepositories::new(self.github.clone(), self.org.clone())
     }
 }
 
-pub struct Organizations<C>
-where
-    C: Clone + Connect + 'static,
-{
-    github: Github<C>,
+pub struct Organizations {
+    github: Github,
 }
 
-impl<C: Clone + Connect + 'static> Organizations<C> {
+impl Organizations {
     #[doc(hidden)]
-    pub fn new(github: Github<C>) -> Self {
+    pub fn new(github: Github) -> Self {
         Self { github }
     }
 
@@ -62,16 +55,13 @@ impl<C: Clone + Connect + 'static> Organizations<C> {
     }
 }
 
-pub struct UserOrganizations<C>
-where
-    C: Clone + Connect + 'static,
-{
-    github: Github<C>,
+pub struct UserOrganizations {
+    github: Github,
     user: String,
 }
 
-impl<C: Clone + Connect + 'static> UserOrganizations<C> {
-    pub fn new<U>(github: Github<C>, user: U) -> Self
+impl UserOrganizations {
+    pub fn new<U>(github: Github, user: U) -> Self
     where
         U: Into<String>,
     {

--- a/src/pull_commits.rs
+++ b/src/pull_commits.rs
@@ -1,24 +1,20 @@
 //! Pull Commits interface
-use hyper::client::connect::Connect;
 use serde::Deserialize;
 
 use crate::users::User;
 use crate::{Future, Github, Stream};
 
 /// A structure for interfacing with a pull commits
-pub struct PullCommits<C>
-where
-    C: Clone + Connect + 'static,
-{
-    github: Github<C>,
+pub struct PullCommits {
+    github: Github,
     owner: String,
     repo: String,
     number: u64,
 }
 
-impl<C: Clone + Connect + 'static> PullCommits<C> {
+impl PullCommits {
     #[doc(hidden)]
-    pub fn new<O, R>(github: Github<C>, owner: O, repo: R, number: u64) -> Self
+    pub fn new<O, R>(github: Github, owner: O, repo: R, number: u64) -> Self
     where
         O: Into<String>,
         R: Into<String>,

--- a/src/pulls.rs
+++ b/src/pulls.rs
@@ -2,7 +2,6 @@
 use std::collections::HashMap;
 use std::fmt;
 
-use hyper::client::connect::Connect;
 use url::form_urlencoded;
 use serde::{Deserialize, Serialize};
 
@@ -47,19 +46,16 @@ impl Default for Sort {
 }
 
 /// A structure for accessing interfacing with a specific pull request
-pub struct PullRequest<C>
-where
-    C: Clone + Connect + 'static,
-{
-    github: Github<C>,
+pub struct PullRequest {
+    github: Github,
     owner: String,
     repo: String,
     number: u64,
 }
 
-impl<C: Clone + Connect + 'static> PullRequest<C> {
+impl PullRequest {
     #[doc(hidden)]
-    pub fn new<O, R>(github: Github<C>, owner: O, repo: R, number: u64) -> Self
+    pub fn new<O, R>(github: Github, owner: O, repo: R, number: u64) -> Self
     where
         O: Into<String>,
         R: Into<String>,
@@ -85,7 +81,7 @@ impl<C: Clone + Connect + 'static> PullRequest<C> {
     }
 
     /// Return a reference to labels operations available for this pull request
-    pub fn labels(&self) -> IssueLabels<C> {
+    pub fn labels(&self) -> IssueLabels {
         IssueLabels::new(
             self.github.clone(),
             self.owner.as_str(),
@@ -95,7 +91,7 @@ impl<C: Clone + Connect + 'static> PullRequest<C> {
     }
 
     /// Return a reference to assignee operations available for this pull request
-    pub fn assignees(&self) -> IssueAssignees<C> {
+    pub fn assignees(&self) -> IssueAssignees {
         IssueAssignees::new(
             self.github.clone(),
             self.owner.as_str(),
@@ -125,7 +121,7 @@ impl<C: Clone + Connect + 'static> PullRequest<C> {
     }
 
     /// returns issue comments interface
-    pub fn comments(&self) -> Comments<C> {
+    pub fn comments(&self) -> Comments {
         Comments::new(
             self.github.clone(),
             self.owner.clone(),
@@ -135,7 +131,7 @@ impl<C: Clone + Connect + 'static> PullRequest<C> {
     }
 
     /// returns review comments interface
-    pub fn review_comments(&self) -> ReviewComments<C> {
+    pub fn review_comments(&self) -> ReviewComments {
         ReviewComments::new(
             self.github.clone(),
             self.owner.clone(),
@@ -144,7 +140,7 @@ impl<C: Clone + Connect + 'static> PullRequest<C> {
         )
     }
 
-    pub fn review_requests(&self) -> ReviewRequests<C> {
+    pub fn review_requests(&self) -> ReviewRequests {
         ReviewRequests::new(
             self.github.clone(),
             self.owner.clone(),
@@ -154,7 +150,7 @@ impl<C: Clone + Connect + 'static> PullRequest<C> {
     }
 
     /// returns pull commits interface
-    pub fn commits(&self) -> PullCommits<C> {
+    pub fn commits(&self) -> PullCommits {
         PullCommits::new(
             self.github.clone(),
             self.owner.clone(),
@@ -165,18 +161,15 @@ impl<C: Clone + Connect + 'static> PullRequest<C> {
 }
 
 /// A structure for interfacing with a repositories list of pull requests
-pub struct PullRequests<C>
-where
-    C: Clone + Connect + 'static,
-{
-    github: Github<C>,
+pub struct PullRequests {
+    github: Github,
     owner: String,
     repo: String,
 }
 
-impl<C: Clone + Connect + 'static> PullRequests<C> {
+impl PullRequests {
     #[doc(hidden)]
-    pub fn new<O, R>(github: Github<C>, owner: O, repo: R) -> Self
+    pub fn new<O, R>(github: Github, owner: O, repo: R) -> Self
     where
         O: Into<String>,
         R: Into<String>,
@@ -193,7 +186,7 @@ impl<C: Clone + Connect + 'static> PullRequests<C> {
     }
 
     /// Get a reference to a structure for interfacing with a specific pull request
-    pub fn get(&self, number: u64) -> PullRequest<C> {
+    pub fn get(&self, number: u64) -> PullRequest {
         PullRequest::new(
             self.github.clone(),
             self.owner.as_str(),

--- a/src/rate_limit.rs
+++ b/src/rate_limit.rs
@@ -1,16 +1,15 @@
 //! Rate Limit interface
-use hyper::client::connect::Connect;
 use serde::Deserialize;
 
 use crate::{Future, Github};
 
-pub struct RateLimit<C: Clone + Connect + 'static> {
-    github: Github<C>,
+pub struct RateLimit {
+    github: Github,
 }
 
-impl<C: Clone + Connect + 'static> RateLimit<C> {
+impl RateLimit {
     #[doc(hidden)]
-    pub fn new(github: Github<C>) -> Self {
+    pub fn new(github: Github) -> Self {
         Self { github }
     }
 

--- a/src/releases.rs
+++ b/src/releases.rs
@@ -1,5 +1,4 @@
 //! Releases interface
-use hyper::client::connect::Connect;
 use serde::{Deserialize, Serialize};
 
 use crate::users::User;
@@ -8,19 +7,16 @@ use crate::{Future, Github};
 /// Provides access to assets for a release.
 /// See the [github docs](https://developer.github.com/v3/repos/releases/)
 /// for more information.
-pub struct Assets<C>
-where
-    C: Clone + Connect + 'static,
-{
-    github: Github<C>,
+pub struct Assets {
+    github: Github,
     owner: String,
     repo: String,
     releaseid: u64,
 }
 
-impl<C: Clone + Connect + 'static> Assets<C> {
+impl Assets {
     #[doc(hidden)]
-    pub fn new<O, R>(github: Github<C>, owner: O, repo: R, releaseid: u64) -> Self
+    pub fn new<O, R>(github: Github, owner: O, repo: R, releaseid: u64) -> Self
     where
         O: Into<String>,
         R: Into<String>,
@@ -70,19 +66,19 @@ impl<C: Clone + Connect + 'static> Assets<C> {
     }
 }
 
-pub struct ReleaseRef<C>
+pub struct ReleaseRef
 where
-    C: Clone + Connect + 'static,
+    
 {
-    github: Github<C>,
+    github: Github,
     owner: String,
     repo: String,
     id: u64,
 }
 
-impl<C: Clone + Connect + 'static> ReleaseRef<C> {
+impl ReleaseRef {
     #[doc(hidden)]
-    pub fn new<O, R>(github: Github<C>, owner: O, repo: R, id: u64) -> Self
+    pub fn new<O, R>(github: Github, owner: O, repo: R, id: u64) -> Self
     where
         O: Into<String>,
         R: Into<String>,
@@ -111,7 +107,7 @@ impl<C: Clone + Connect + 'static> ReleaseRef<C> {
     }
 
     /// Get a reference to asset operations for a release.
-    pub fn assets(&self) -> Assets<C> {
+    pub fn assets(&self) -> Assets {
         Assets::new(
             self.github.clone(),
             self.owner.as_str(),
@@ -124,18 +120,18 @@ impl<C: Clone + Connect + 'static> ReleaseRef<C> {
 /// Provides access to published releases.
 /// See the [github docs](https://developer.github.com/v3/repos/releases/)
 /// for more information.
-pub struct Releases<C>
+pub struct Releases
 where
-    C: Clone + Connect + 'static,
+    
 {
-    github: Github<C>,
+    github: Github,
     owner: String,
     repo: String,
 }
 
-impl<C: Clone + Connect + 'static> Releases<C> {
+impl Releases {
     #[doc(hidden)]
-    pub fn new<O, R>(github: Github<C>, owner: O, repo: R) -> Self
+    pub fn new<O, R>(github: Github, owner: O, repo: R) -> Self
     where
         O: Into<String>,
         R: Into<String>,
@@ -205,7 +201,7 @@ impl<C: Clone + Connect + 'static> Releases<C> {
     }
 
     /// Get a reference to a specific release associated with a repository
-    pub fn get(&self, id: u64) -> ReleaseRef<C> {
+    pub fn get(&self, id: u64) -> ReleaseRef {
         ReleaseRef::new(
             self.github.clone(),
             self.owner.as_str(),

--- a/src/repositories.rs
+++ b/src/repositories.rs
@@ -2,7 +2,6 @@
 use std::collections::HashMap;
 use std::fmt;
 
-use hyper::client::connect::Connect;
 use url::{form_urlencoded, Url};
 use serde::{Deserialize, Serialize};
 
@@ -132,16 +131,13 @@ impl fmt::Display for OrgRepoType {
 }
 
 #[derive(Clone)]
-pub struct Repositories<C>
-where
-    C: Clone + Connect + 'static,
-{
-    github: Github<C>,
+pub struct Repositories {
+    github: Github,
 }
 
-impl<C: Clone + Connect + 'static> Repositories<C> {
+impl Repositories {
     #[doc(hidden)]
-    pub fn new(github: Github<C>) -> Self {
+    pub fn new(github: Github) -> Self {
         Self { github }
     }
 
@@ -177,17 +173,14 @@ impl<C: Clone + Connect + 'static> Repositories<C> {
 }
 
 /// Provides access to the authenticated user's repositories
-pub struct OrgRepositories<C>
-where
-    C: Clone + Connect + 'static,
-{
-    github: Github<C>,
+pub struct OrgRepositories {
+    github: Github,
     org: String,
 }
 
-impl<C: Clone + Connect + 'static> OrgRepositories<C> {
+impl OrgRepositories {
     #[doc(hidden)]
-    pub fn new<O>(github: Github<C>, org: O) -> Self
+    pub fn new<O>(github: Github, org: O) -> Self
     where
         O: Into<String>,
     {
@@ -228,17 +221,14 @@ impl<C: Clone + Connect + 'static> OrgRepositories<C> {
 }
 
 /// Provides access to the authenticated user's repositories
-pub struct UserRepositories<C>
-where
-    C: Clone + Connect + 'static,
-{
-    github: Github<C>,
+pub struct UserRepositories {
+    github: Github,
     owner: String,
 }
 
-impl<C: Clone + Connect + 'static> UserRepositories<C> {
+impl UserRepositories {
     #[doc(hidden)]
-    pub fn new<O>(github: Github<C>, owner: O) -> Self
+    pub fn new<O>(github: Github, owner: O) -> Self
     where
         O: Into<String>,
     {
@@ -270,17 +260,14 @@ impl<C: Clone + Connect + 'static> UserRepositories<C> {
 }
 
 /// Provides access to an organization's repositories
-pub struct OrganizationRepositories<C>
-where
-    C: Clone + Connect + 'static,
-{
-    github: Github<C>,
+pub struct OrganizationRepositories {
+    github: Github,
     org: String,
 }
 
-impl<C: Clone + Connect + 'static> OrganizationRepositories<C> {
+impl OrganizationRepositories {
     #[doc(hidden)]
-    pub fn new<O>(github: Github<C>, org: O) -> Self
+    pub fn new<O>(github: Github, org: O) -> Self
     where
         O: Into<String>,
     {
@@ -315,18 +302,15 @@ impl<C: Clone + Connect + 'static> OrganizationRepositories<C> {
     }
 }
 
-pub struct Repository<C>
-where
-    C: Clone + Connect + 'static,
-{
-    github: Github<C>,
+pub struct Repository {
+    github: Github,
     owner: String,
     repo: String,
 }
 
-impl<C: Clone + Connect + 'static> Repository<C> {
+impl Repository {
     #[doc(hidden)]
-    pub fn new<O, R>(github: Github<C>, owner: O, repo: R) -> Self
+    pub fn new<O, R>(github: Github, owner: O, repo: R) -> Self
     where
         O: Into<String>,
         R: Into<String>,
@@ -361,33 +345,33 @@ impl<C: Clone + Connect + 'static> Repository<C> {
     }
 
     /// get a reference to branch operations
-    pub fn branches(&self) -> Branches<C> {
+    pub fn branches(&self) -> Branches {
         Branches::new(self.github.clone(), self.owner.as_str(), self.repo.as_str())
     }
 
     /// get a reference to content operations
-    pub fn content(&self) -> Content<C> {
+    pub fn content(&self) -> Content {
         Content::new(self.github.clone(), self.owner.as_str(), self.repo.as_str())
     }
 
     /// get a reference to git operations
-    pub fn git(&self) -> Git<C> {
+    pub fn git(&self) -> Git {
         Git::new(self.github.clone(), self.owner.as_str(), self.repo.as_str())
     }
 
     /// get a reference to repo hook operations
-    pub fn hooks(&self) -> Hooks<C> {
+    pub fn hooks(&self) -> Hooks {
         Hooks::new(self.github.clone(), self.owner.as_str(), self.repo.as_str())
     }
 
     /// get a reference to [deployments](https://developer.github.com/v3/repos/deployments/)
     /// associated with this repository ref
-    pub fn deployments(&self) -> Deployments<C> {
+    pub fn deployments(&self) -> Deployments {
         Deployments::new(self.github.clone(), self.owner.as_str(), self.repo.as_str())
     }
 
     /// get a reference to a specific github issue associated with this repository ref
-    pub fn issue(&self, number: u64) -> IssueRef<C> {
+    pub fn issue(&self, number: u64) -> IssueRef {
         IssueRef::new(
             self.github.clone(),
             self.owner.as_str(),
@@ -397,60 +381,60 @@ impl<C: Clone + Connect + 'static> Repository<C> {
     }
 
     /// get a reference to github issues associated with this repository ref
-    pub fn issues(&self) -> Issues<C> {
+    pub fn issues(&self) -> Issues {
         Issues::new(self.github.clone(), self.owner.as_str(), self.repo.as_str())
     }
 
     /// get a reference to github checks associated with this repository ref
-    pub fn checkruns(&self) -> CheckRuns<C> {
+    pub fn checkruns(&self) -> CheckRuns {
         CheckRuns::new(self.github.clone(), self.owner.as_str(), self.repo.as_str())
     }
 
     /// get a reference to [deploy keys](https://developer.github.com/v3/repos/keys/)
     /// associated with this repository ref
-    pub fn keys(&self) -> Keys<C> {
+    pub fn keys(&self) -> Keys {
         Keys::new(self.github.clone(), self.owner.as_str(), self.repo.as_str())
     }
 
     /// get a list of labels associated with this repository ref
-    pub fn labels(&self) -> Labels<C> {
+    pub fn labels(&self) -> Labels {
         Labels::new(self.github.clone(), self.owner.as_str(), self.repo.as_str())
     }
 
     /// get a list of [pulls](https://developer.github.com/v3/pulls/)
     /// associated with this repository ref
-    pub fn pulls(&self) -> PullRequests<C> {
+    pub fn pulls(&self) -> PullRequests {
         PullRequests::new(self.github.clone(), self.owner.as_str(), self.repo.as_str())
     }
 
     /// get a reference to [releases](https://developer.github.com/v3/repos/releases/)
     /// associated with this repository ref
-    pub fn releases(&self) -> Releases<C> {
+    pub fn releases(&self) -> Releases {
         Releases::new(self.github.clone(), self.owner.as_str(), self.repo.as_str())
     }
 
     /// get a reference to [statuses](https://developer.github.com/v3/repos/statuses/)
     /// associated with this repository ref
-    pub fn statuses(&self) -> Statuses<C> {
+    pub fn statuses(&self) -> Statuses {
         Statuses::new(self.github.clone(), self.owner.as_str(), self.repo.as_str())
     }
 
     /// get a reference to [teams](https://developer.github.com/v3/repos/#list-teams)
     /// associated with this repository ref
-    pub fn teams(&self) -> RepoTeams<C> {
+    pub fn teams(&self) -> RepoTeams {
         RepoTeams::new(self.github.clone(), self.owner.as_str(), self.repo.as_str())
     }
 
     /// get a reference to
     /// [contributors](https://developer.github.com/v3/repos/#list-contributors)
     /// associated with this repository ref
-    pub fn contributors(&self) -> Contributors<C> {
+    pub fn contributors(&self) -> Contributors {
         Contributors::new(self.github.clone(), self.owner.as_str(), self.repo.as_str())
     }
 
     /// get a reference of [traffic](https://developer.github.com/v3/repos/traffic/)
     /// associated with this repository ref
-    pub fn traffic(&self) -> Traffic<C> {
+    pub fn traffic(&self) -> Traffic {
         Traffic::new(self.github.clone(), self.owner.as_str(), self.repo.as_str())
     }
 }
@@ -535,10 +519,7 @@ impl Repo {
     /// The keys are the language names, and the values are the number of bytes of code written in
     /// that language.
     #[allow(clippy::needless_pass_by_value)] // shipped public API
-    pub fn languages<C>(&self, github: Github<C>) -> Future<HashMap<String, i64>>
-    where
-        C: Clone + Connect + 'static,
-    {
+    pub fn languages(&self, github: Github) -> Future<HashMap<String, i64>> {
         let url = Url::parse(&self.languages_url).unwrap();
         let uri: String = url.path().into();
         github.get(&uri)

--- a/src/review_comments.rs
+++ b/src/review_comments.rs
@@ -1,24 +1,20 @@
 //! Review comments interface
-use hyper::client::connect::Connect;
 use serde::{Deserialize, Serialize};
 
 use crate::users::User;
 use crate::{Future, Github};
 
 /// A structure for interfacing with a review comments
-pub struct ReviewComments<C>
-where
-    C: Clone + Connect + 'static,
-{
-    github: Github<C>,
+pub struct ReviewComments {
+    github: Github,
     owner: String,
     repo: String,
     number: u64,
 }
 
-impl<C: Clone + Connect + 'static> ReviewComments<C> {
+impl ReviewComments {
     #[doc(hidden)]
-    pub fn new<O, R>(github: Github<C>, owner: O, repo: R, number: u64) -> Self
+    pub fn new<O, R>(github: Github, owner: O, repo: R, number: u64) -> Self
     where
         O: Into<String>,
         R: Into<String>,

--- a/src/review_requests.rs
+++ b/src/review_requests.rs
@@ -1,5 +1,4 @@
 //! Review requests interface
-use hyper::client::connect::Connect;
 use serde::{Deserialize, Serialize};
 
 use crate::pulls::Pull;
@@ -8,19 +7,16 @@ use crate::users::User;
 use crate::{Future, Github};
 
 /// A structure for interfacing with review requests
-pub struct ReviewRequests<C>
-where
-    C: Clone + Connect + 'static,
-{
-    github: Github<C>,
+pub struct ReviewRequests {
+    github: Github,
     owner: String,
     repo: String,
     number: u64,
 }
 
-impl<C: Clone + Connect + 'static> ReviewRequests<C> {
+impl ReviewRequests {
     #[doc(hidden)]
-    pub fn new<O, R>(github: Github<C>, owner: O, repo: R, number: u64) -> Self
+    pub fn new<O, R>(github: Github, owner: O, repo: R, number: u64) -> Self
     where
         O: Into<String>,
         R: Into<String>,

--- a/src/search.rs
+++ b/src/search.rs
@@ -2,7 +2,6 @@
 use std::collections::HashMap;
 use std::fmt;
 
-use hyper::client::connect::Connect;
 use serde::de::DeserializeOwned;
 use url::{self, form_urlencoded};
 use serde::Deserialize;
@@ -40,11 +39,8 @@ impl fmt::Display for IssuesSort {
 /// Provides access to general search operations
 ///
 #[derive(Clone)]
-pub struct Search<C>
-where
-    C: Clone + Connect + 'static,
-{
-    github: Github<C>,
+pub struct Search {
+    github: Github,
 }
 
 fn items<D>(result: SearchResult<D>) -> Vec<D>
@@ -54,19 +50,19 @@ where
     result.items
 }
 
-impl<C: Clone + Connect + 'static> Search<C> {
+impl Search {
     #[doc(hidden)]
-    pub fn new(github: Github<C>) -> Self {
+    pub fn new(github: Github) -> Self {
         Self { github }
     }
 
     /// return a reference to a search interface for issues
-    pub fn issues(&self) -> SearchIssues<C> {
+    pub fn issues(&self) -> SearchIssues {
         SearchIssues::new(self.clone())
     }
 
     /// Return a reference to a search interface for repositories
-    pub fn repos(&self) -> SearchRepos<C> {
+    pub fn repos(&self) -> SearchRepos {
         SearchRepos::new(self.clone())
     }
 
@@ -87,16 +83,13 @@ impl<C: Clone + Connect + 'static> Search<C> {
 
 /// Provides access to issue search operations
 /// https://developer.github.com/v3/search/#search-issues
-pub struct SearchIssues<C>
-where
-    C: Clone + Connect + 'static,
-{
-    search: Search<C>,
+pub struct SearchIssues {
+    search: Search,
 }
 
-impl<C: Clone + Connect + 'static> SearchIssues<C> {
+impl SearchIssues {
     #[doc(hidden)]
-    pub fn new(search: Search<C>) -> Self {
+    pub fn new(search: Search) -> Self {
         Self { search }
     }
 

--- a/src/search/repos.rs
+++ b/src/search/repos.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 use std::fmt;
 
 use url::form_urlencoded;
-use hyper::client::connect::Connect;
 use serde::Deserialize;
 
 use super::{Search, SearchResult};
@@ -32,16 +31,13 @@ impl fmt::Display for ReposSort {
 
 /// Provides access to [search operations for repositories](https://developer.github.com/v3/search/#search-repositories)
 ///
-pub struct SearchRepos<C>
-where
-    C: Clone + Connect + 'static,
-{
-    search: Search<C>,
+pub struct SearchRepos {
+    search: Search,
 }
 
-impl<C: Clone + Connect + 'static> SearchRepos<C> {
+impl SearchRepos {
     #[doc(hidden)]
-    pub fn new(search: Search<C>) -> Self {
+    pub fn new(search: Search) -> Self {
         Self { search }
     }
 

--- a/src/stars.rs
+++ b/src/stars.rs
@@ -1,21 +1,16 @@
 //! Stars interface
-
 use futures::Future as StdFuture;
-use hyper::client::connect::Connect;
 use hyper::StatusCode;
 
 use crate::{Error, ErrorKind, Future, Github};
 
-pub struct Stars<C>
-where
-    C: Clone + Connect + 'static,
-{
-    github: Github<C>,
+pub struct Stars {
+    github: Github,
 }
 
-impl<C: Clone + Connect + 'static> Stars<C> {
+impl Stars {
     #[doc(hidden)]
-    pub fn new(github: Github<C>) -> Self {
+    pub fn new(github: Github) -> Self {
         Self { github }
     }
 

--- a/src/stars.rs
+++ b/src/stars.rs
@@ -1,6 +1,6 @@
 //! Stars interface
 use futures::Future as StdFuture;
-use hyper::StatusCode;
+use http::StatusCode;
 
 use crate::{Error, ErrorKind, Future, Github};
 

--- a/src/statuses.rs
+++ b/src/statuses.rs
@@ -1,23 +1,19 @@
 //! Statuses interface
-use hyper::client::connect::Connect;
 use serde::{Deserialize, Serialize};
 
 use crate::users::User;
 use crate::{Future, Github};
 
 /// interface for statuses associated with a repository
-pub struct Statuses<C>
-where
-    C: Clone + Connect + 'static,
-{
-    github: Github<C>,
+pub struct Statuses {
+    github: Github,
     owner: String,
     repo: String,
 }
 
-impl<C: Clone + Connect + 'static> Statuses<C> {
+impl Statuses {
     #[doc(hidden)]
-    pub fn new<O, R>(github: Github<C>, owner: O, repo: R) -> Self
+    pub fn new<O, R>(github: Github, owner: O, repo: R) -> Self
     where
         O: Into<String>,
         R: Into<String>,

--- a/src/teams.rs
+++ b/src/teams.rs
@@ -1,7 +1,6 @@
 //! Teams interface
 use std::fmt;
 
-use hyper::client::connect::Connect;
 use serde::{Deserialize, Serialize};
 
 use crate::users::User;
@@ -27,18 +26,15 @@ impl fmt::Display for Permission {
 }
 
 /// reference to teams associated with a github repo
-pub struct RepoTeams<C>
-where
-    C: Clone + Connect + 'static,
-{
-    github: Github<C>,
+pub struct RepoTeams {
+    github: Github,
     owner: String,
     repo: String,
 }
 
-impl<C: Clone + Connect + 'static> RepoTeams<C> {
+impl RepoTeams {
     #[doc(hidden)]
-    pub fn new<O, R>(github: Github<C>, owner: O, repo: R) -> Self
+    pub fn new<O, R>(github: Github, owner: O, repo: R) -> Self
     where
         O: Into<String>,
         R: Into<String>,
@@ -64,17 +60,14 @@ impl<C: Clone + Connect + 'static> RepoTeams<C> {
 }
 
 /// reference to teams associated with a github org
-pub struct OrgTeams<C>
-where
-    C: Clone + Connect + 'static,
-{
-    github: Github<C>,
+pub struct OrgTeams {
+    github: Github,
     org: String,
 }
 
-impl<C: Clone + Connect + 'static> OrgTeams<C> {
+impl OrgTeams {
     #[doc(hidden)]
-    pub fn new<O>(github: Github<C>, org: O) -> Self
+    pub fn new<O>(github: Github, org: O) -> Self
     where
         O: Into<String>,
     {
@@ -91,7 +84,7 @@ impl<C: Clone + Connect + 'static> OrgTeams<C> {
 
     /// Get a reference to a structure for interfacing with a specific
     /// team
-    pub fn get(&self, number: u64) -> OrgTeamActions<C> {
+    pub fn get(&self, number: u64) -> OrgTeamActions {
         OrgTeamActions::new(self.github.clone(), number)
     }
 
@@ -125,17 +118,14 @@ impl<C: Clone + Connect + 'static> OrgTeams<C> {
 }
 
 /// reference to teams associated with a github org
-pub struct OrgTeamActions<C>
-where
-    C: Clone + Connect + 'static,
-{
-    github: Github<C>,
+pub struct OrgTeamActions {
+    github: Github,
     number: u64,
 }
 
-impl<C: Clone + Connect + 'static> OrgTeamActions<C> {
+impl OrgTeamActions {
     #[doc(hidden)]
-    pub fn new(github: Github<C>, number: u64) -> Self {
+    pub fn new(github: Github, number: u64) -> Self {
         OrgTeamActions { github, number }
     }
 

--- a/src/traffic.rs
+++ b/src/traffic.rs
@@ -1,7 +1,6 @@
 //! Traffic interface
 use std::fmt;
 
-use hyper::client::connect::Connect;
 use serde::Deserialize;
 
 use crate::{Future, Github};
@@ -24,18 +23,15 @@ impl fmt::Display for TimeUnit {
 }
 
 /// Provides access to the traffic information for a repository
-pub struct Traffic<C>
-where
-    C: Clone + Connect + 'static,
-{
-    github: Github<C>,
+pub struct Traffic {
+    github: Github,
     owner: String,
     repo: String,
 }
 
-impl<C: Clone + Connect + 'static> Traffic<C> {
+impl Traffic {
     #[doc(hidden)]
-    pub fn new<O, R>(github: Github<C>, owner: O, repo: R) -> Self
+    pub fn new<O, R>(github: Github, owner: O, repo: R) -> Self
     where
         O: Into<String>,
         R: Into<String>,

--- a/src/users.rs
+++ b/src/users.rs
@@ -2,8 +2,6 @@
 use crate::{Future, Github, Stream};
 use serde::Deserialize;
 
-use hyper::client::connect::Connect;
-
 /// User information
 #[derive(Debug, Deserialize)]
 pub struct User {
@@ -64,15 +62,12 @@ pub struct AuthenticatedUser {
 }
 
 /// Query user information
-pub struct Users<C>
-where
-    C: Clone + Connect + 'static,
-{
-    github: Github<C>,
+pub struct Users {
+    github: Github,
 }
 
-impl<C: Clone + Connect + 'static> Users<C> {
-    pub fn new(github: Github<C>) -> Self {
+impl Users {
+    pub fn new(github: Github) -> Self {
         Users { github }
     }
 
@@ -91,18 +86,15 @@ impl<C: Clone + Connect + 'static> Users<C> {
 }
 
 /// reference to contributors associated with a github repo
-pub struct Contributors<C>
-where
-    C: Clone + Connect + 'static,
-{
-    github: Github<C>,
+pub struct Contributors {
+    github: Github,
     owner: String,
     repo: String,
 }
 
-impl<C: Clone + Connect + 'static> Contributors<C> {
+impl Contributors {
     #[doc(hidden)]
-    pub fn new<O, R>(github: Github<C>, owner: O, repo: R) -> Self
+    pub fn new<O, R>(github: Github, owner: O, repo: R) -> Self
     where
         O: Into<String>,
         R: Into<String>,

--- a/src/watching.rs
+++ b/src/watching.rs
@@ -1,21 +1,17 @@
 //! Watching interface
 /// https://developer.github.com/v3/activity/watching
-use hyper::client::connect::Connect;
 use serde::Deserialize;
 
 use crate::repositories::Repo;
 use crate::{Future, Github, Stream};
 
-pub struct Watching<C>
-where
-    C: Clone + Connect + 'static,
-{
-    github: Github<C>,
+pub struct Watching {
+    github: Github,
 }
 
-impl<C: Clone + Connect + 'static> Watching<C> {
+impl Watching {
     #[doc(hidden)]
-    pub fn new(github: Github<C>) -> Self {
+    pub fn new(github: Github) -> Self {
         Self { github }
     }
 

--- a/tests/conditional_requests.rs
+++ b/tests/conditional_requests.rs
@@ -3,8 +3,7 @@ use {
     std::env,
 
     futures::{future, Stream},
-    hyper::Client,
-    hyper_tls::HttpsConnector,
+    reqwest::r#async::Client,
     tokio::runtime::Runtime,
     log::info,
 
@@ -41,7 +40,7 @@ fn compare_counts() -> Result<()> {
 
     info!("first get the total count of repos, without caching");
 
-    let github = Github::new(agent, credentials.clone());
+    let github = Github::new(agent, credentials.clone())?;
     let repos = github.user_repos(owner).iter(&repo_list_options);
     let total_count = rt.block_on(repos.fold(0, |acc, _repo| future::ok::<_, Error>(acc + 1)))?;
 
@@ -58,10 +57,10 @@ fn compare_counts() -> Result<()> {
     info!("then get the total count with a cache");
 
     let host = "https://api.github.com";
-    let client = Client::builder().build(HttpsConnector::new(4).unwrap());
+    let client = Client::builder().build()?;
     let cache_path = testkit::test_home().join(".hubcaps/cache");
     let http_cache = Box::new(FileBasedCache::new(cache_path));
-    let github: Github<_> = Github::custom(host, agent, credentials, client, http_cache);
+    let github = Github::custom(host, agent, credentials, client, http_cache);
 
     info!("first populate the cache");
 


### PR DESCRIPTION
## What did you implement:
Closes: #210 

#### How did you verify your change:
builds with `default-tls` and `rustls-tls` and `examples/users` works with both tls implementations.

#### What (if anything) would need to be called out in the CHANGELOG for the next release:
Breaking change because of the remove of the type parameters and changed `Github::custom|host|new` methods