### PR TITLE
Handle newlines in base64 encoded content

### DIFF
--- a/src/content.rs
+++ b/src/content.rs
@@ -189,7 +189,12 @@ impl<'de> Deserialize<'de> for DecodedContents {
             where
                 E: de::Error,
             {
-                let decoded = base64::decode_config(v, base64::STANDARD).map_err(|e| match e {
+                // GitHub wraps the base64 to column 60. The base64 crate
+                // doesn't handle whitespace, nor does it take a reader, so we
+                // must unfortunately allocate again and remove all new lines.
+                let v = v.replace("\n", "");
+
+                let decoded = base64::decode_config(&v, base64::STANDARD).map_err(|e| match e {
                     base64::DecodeError::InvalidLength => {
                         E::invalid_length(v.len(), &"invalid base64 length")
                     }


### PR DESCRIPTION
This is the same as #204, but has no merge conflicts.