### PR TITLE
Add 'merged' field to pull request

### DIFF
--- a/src/pulls.rs
+++ b/src/pulls.rs
@@ -250,6 +250,7 @@ pub struct Pull {
     pub assignee: Option<User>,
     pub assignees: Vec<User>,
     pub merge_commit_sha: Option<String>,
+    pub merged: bool,
     pub mergeable: Option<bool>,
     pub merged_by: Option<User>,
     pub comments: Option<u64>,


### PR DESCRIPTION
This field appears to always exists in pull requests and is pretty useful.

Is adding a new field to a struct considered a breaking change? If so, it's going to be hard to fix missing fields.