### PR TITLE
Update protections support to match current API

### DIFF
--- a/src/branches.rs
+++ b/src/branches.rs
@@ -4,7 +4,7 @@
 //! [Github docs](https://developer.github.com/v3/repos/branches/)
 use serde::{Deserialize, Serialize};
 
-use crate::{Future, Github, Stream};
+use crate::{Future, Github, Stream, MediaType};
 
 /// reference to gists associated with a github user
 pub struct Branches {
@@ -65,7 +65,7 @@ impl Branches {
     where
         B: Into<String>,
     {
-        self.github.put(
+        self.github.put_media(
             &format!(
                 "/repos/{owner}/{repo}/branches/{branch}/protection",
                 owner = self.owner,
@@ -73,6 +73,7 @@ impl Branches {
                 branch = branch.into()
             ),
             json!(pro),
+            MediaType::Preview("luke-cage")
         )
     }
 }
@@ -117,9 +118,11 @@ pub struct Restrictions {
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct RequiredPullRequestReviews {
-    pub dismissal_restrictions: Restrictions,
+    #[serde(skip_serializing_if="Option::is_none")]
+    pub dismissal_restrictions: Option<Restrictions>,
     pub dismiss_stale_reviews: bool,
     pub require_code_owner_reviews: bool,
+    pub required_approving_review_count: u8
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -969,11 +969,22 @@ impl Github {
     where
         D: DeserializeOwned + 'static + Send,
     {
+        self.put_media(
+            uri,
+            message,
+            MediaType::Json
+        )
+    }
+
+    fn put_media<D>(&self, uri: &str, message: Vec<u8>, media: MediaType) -> Future<D>
+    where
+        D: DeserializeOwned + 'static + Send,
+    {
         self.request_entity(
             Method::PUT,
             &(self.host.clone() + uri),
             Some(message),
-            MediaType::Json,
+            media,
             AuthenticationConstraint::Unconstrained,
         )
     }


### PR DESCRIPTION
## What did you implement:

Updated branch protection support to work with current (and preview) protection API

#### How did you verify your change:

Tested locally on own repos.

#### What (if anything) would need to be called out in the CHANGELOG for the next release:

That `dismissal_restrictions` are now optional when defining `RequiredPullRequestReviews` and that `required_approving_review_count` may now be specified.