### PR TITLE
repositories: support listing commits

### DIFF
--- a/examples/repo_commits.rs
+++ b/examples/repo_commits.rs
@@ -1,0 +1,32 @@
+use std::env;
+
+use tokio::runtime::Runtime;
+
+use hubcaps::{Credentials, Github, Result};
+
+fn main() -> Result<()> {
+    pretty_env_logger::init();
+    let mut rt = Runtime::new()?;
+    let github = Github::new(
+        concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
+        env::var("GITHUB_TOKEN")
+            .ok()
+            .map(|token| Credentials::Token(token)),
+    )?;
+
+    let first_commit = rt.block_on(
+        github
+            .repo("softprops", "hubcaps")
+            .commits()
+            .get("1758957ddab20ba17a1fa501f31932d1a9d96f78"),
+    )?;
+    println!("Check out the first commit: {:#?}", first_commit);
+
+    println!("Here are some more recent commits:");
+    let commits = rt.block_on(github.repo("softprops", "hubcaps").commits().list())?;
+    for commit in commits {
+        println!(" - {}", commit.author.login);
+    }
+    println!("Thank you for your help!");
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,6 +129,7 @@ pub mod pull_commits;
 pub mod pulls;
 pub mod rate_limit;
 pub mod releases;
+pub mod repo_commits;
 pub mod repositories;
 pub mod review_comments;
 pub mod review_requests;

--- a/src/repo_commits.rs
+++ b/src/repo_commits.rs
@@ -1,0 +1,92 @@
+//! Repo Commits interface
+//! https://developer.github.com/v3/repos/commits/#get-a-single-commit
+use serde::Deserialize;
+
+use crate::users::User;
+use crate::{Future, Github, Stream};
+
+/// A structure for interfacing with a repository commits
+pub struct RepoCommits {
+    github: Github,
+    owner: String,
+    repo: String,
+}
+
+impl RepoCommits {
+    #[doc(hidden)]
+    pub fn new<O, R>(github: Github, owner: O, repo: R) -> Self
+    where
+        O: Into<String>,
+        R: Into<String>,
+    {
+        RepoCommits {
+            github,
+            owner: owner.into(),
+            repo: repo.into(),
+        }
+    }
+
+    /// list repo commits
+    /// !!! make optional parameters
+    pub fn list(&self) -> Future<Vec<RepoCommit>> {
+        let uri = format!("/repos/{}/{}/commits", self.owner, self.repo);
+        self.github.get::<Vec<RepoCommit>>(&uri)
+    }
+
+    /// provides a stream over all pages of pull commits
+    /// !!! make optional parameters
+    pub fn iter(&self) -> Stream<RepoCommit> {
+        self.github
+            .get_stream(&format!("/repos/{}/{}/commits", self.owner, self.repo))
+    }
+
+    /// get a repo commit
+    pub fn get(&self, commit_ref: &str) -> Future<RepoCommit> {
+        let uri = format!("/repos/{}/{}/commits/{}", self.owner, self.repo, commit_ref);
+        self.github.get::<RepoCommit>(&uri)
+    }
+}
+
+// representations
+
+// !!! RepoCommit, CommitDetails, CommitRef, UserStamp are exact
+//     dupes of pull_commits.rs' representations.
+
+/// Representation of a repo commit
+#[derive(Debug, Deserialize)]
+pub struct RepoCommit {
+    pub url: String,
+    pub sha: String,
+    pub html_url: String,
+    pub comments_url: String,
+    pub commit: CommitDetails,
+    pub author: User,
+    pub committer: User,
+    pub parents: Vec<CommitRef>,
+}
+
+/// Representation of a repo commit details
+#[derive(Debug, Deserialize)]
+pub struct CommitDetails {
+    pub url: String,
+    pub author: UserStamp,
+    pub committer: Option<UserStamp>,
+    pub message: String,
+    pub tree: CommitRef,
+    pub comment_count: u64,
+}
+
+/// Representation of a reference to a commit
+#[derive(Debug, Deserialize)]
+pub struct CommitRef {
+    pub url: String,
+    pub sha: String,
+}
+
+/// Representation of a git user
+#[derive(Debug, Deserialize)]
+pub struct UserStamp {
+    pub name: String,
+    pub email: String,
+    pub date: String,
+}

--- a/src/repositories.rs
+++ b/src/repositories.rs
@@ -16,6 +16,7 @@ use crate::keys::Keys;
 use crate::labels::Labels;
 use crate::pulls::PullRequests;
 use crate::releases::Releases;
+use crate::repo_commits::RepoCommits;
 use crate::statuses::Statuses;
 use crate::teams::RepoTeams;
 use crate::traffic::Traffic;
@@ -348,6 +349,11 @@ impl Repository {
     /// get a reference to branch operations
     pub fn branches(&self) -> Branches {
         Branches::new(self.github.clone(), self.owner.as_str(), self.repo.as_str())
+    }
+
+    /// get a reference to repository commit operations
+    pub fn commits(&self) -> RepoCommits {
+        RepoCommits::new(self.github.clone(), self.owner.as_str(), self.repo.as_str())
     }
 
     /// get a reference to content operations


### PR DESCRIPTION
## What did you implement:

https://developer.github.com/v3/repos/commits/

1. list commits
2. get a single commit

Has a couple todos, called out with github comments. What do you think from here?

#### How did you verify your change:

```
cargo run --example repo_commits
cargo test
```

I also `cargo fmt`'d my added changes, and didn't add unrelated reformats.

#### What (if anything) would need to be called out in the CHANGELOG for the next release:

nothing, I think :)