### PR TITLE
Update deps: base64, dirs, hyperx & percent-encoding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ serde_derive = "1.0"
 serde_json = "1.0"
 error-chain = "0.12"
 base64 = "0.11"
-percent-encoding = "1"
+percent-encoding = "2"
 
 [features]
 default = ["default-tls"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,10 +22,10 @@ pretty_env_logger = "0.3"
 tokio = "0.1"
 
 [dependencies]
-dirs = { version = "1.0", optional = true }
+dirs = { version = "2.0", optional = true }
 futures = "0.1"
 http = "0.1"
-hyperx = "0.13"
+hyperx = "1"
 jsonwebtoken = "6"
 mime = "0.3"
 log = "0.4"
@@ -35,7 +35,7 @@ serde = { version = "1.0.84", features = ['derive'] }
 serde_derive = "1.0"
 serde_json = "1.0"
 error-chain = "0.12"
-base64 = "0.10"
+base64 = "0.11"
 percent-encoding = "1"
 
 [features]

--- a/src/content.rs
+++ b/src/content.rs
@@ -2,10 +2,10 @@
 use std::fmt;
 use std::ops;
 
-use percent_encoding::{percent_encode, DEFAULT_ENCODE_SET};
 use serde::Deserialize;
 use serde::de::{self, Visitor};
 
+use crate::utils::{percent_encode, PATH};
 use crate::{Future, Github, Stream};
 
 /// Provides access to the content information for a repository
@@ -32,7 +32,7 @@ impl Content {
     fn path(&self, location: &str) -> String {
         // Handle files with spaces and other characters that can mess up the
         // final URL.
-        let location = percent_encode(location.as_ref(), DEFAULT_ENCODE_SET);
+        let location = percent_encode(location.as_ref(), PATH);
         format!("/repos/{}/{}/contents{}", self.owner, self.repo, location)
     }
 

--- a/src/issues.rs
+++ b/src/issues.rs
@@ -3,12 +3,12 @@ use std::collections::HashMap;
 use std::fmt;
 
 use url::form_urlencoded;
-use percent_encoding::{percent_encode, PATH_SEGMENT_ENCODE_SET};
 use serde::{Deserialize, Serialize};
 
 use crate::comments::Comments;
 use crate::labels::Label;
 use crate::users::User;
+use crate::utils::{percent_encode, PATH_SEGMENT};
 use crate::{Future, Github, SortDirection, Stream};
 
 /// enum representation of github pull and issue state
@@ -141,7 +141,7 @@ impl IssueLabels {
 
     /// remove a label from this issue
     pub fn remove(&self, label: &str) -> Future<()> {
-        let label = percent_encode(label.as_ref(), PATH_SEGMENT_ENCODE_SET);
+        let label = percent_encode(label.as_ref(), PATH_SEGMENT);
         self.github.delete(&self.path(&format!("/{}", label)))
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,6 +174,19 @@ const X_RATELIMIT_LIMIT: &str = "x-ratelimit-limit";
 const X_RATELIMIT_REMAINING: &str = "x-ratelimit-remaining";
 const X_RATELIMIT_RESET: &str = "x-ratelimit-reset";
 
+pub(crate) mod utils {
+    pub use percent_encoding::percent_encode;
+    use percent_encoding::{AsciiSet, CONTROLS};
+
+    /// https://url.spec.whatwg.org/#fragment-percent-encode-set
+    const FRAGMENT: &AsciiSet = &CONTROLS.add(b' ').add(b'"').add(b'<').add(b'>').add(b'`');
+
+    /// https://url.spec.whatwg.org/#path-percent-encode-set
+    pub const PATH: &AsciiSet = &FRAGMENT.add(b'#').add(b'?').add(b'{').add(b'}');
+
+    pub const PATH_SEGMENT: &AsciiSet = &PATH.add(b'/').add(b'%');
+}
+
 /// Github defined Media types
 /// See [this doc](https://developer.github.com/v3/media/) for more for more information
 #[derive(Clone, Copy)]


### PR DESCRIPTION
## What did you implement:
 no-op dependency updates except for `percent-encoding`

`DEFAULT_ENCODE_SET` is no longer available and was replaced in [`url#src/parser.rs`](https://github.com/servo/rust-url/blame/7f1bd6ce1c2fde599a757302a843a60e714c5f72/src/parser.rs#L1122)
 with the internal constant `PATH`.

closes: #224 #220 #231 #240 
