### PR TITLE
Percent-encode label in IssueLabels::remove().

### DIFF
--- a/src/issues.rs
+++ b/src/issues.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use std::fmt;
 
 use url::form_urlencoded;
+use percent_encoding::{percent_encode, PATH_SEGMENT_ENCODE_SET};
 use serde::{Deserialize, Serialize};
 
 use crate::comments::Comments;
@@ -140,6 +141,7 @@ impl IssueLabels {
 
     /// remove a label from this issue
     pub fn remove(&self, label: &str) -> Future<()> {
+        let label = percent_encode(label.as_ref(), PATH_SEGMENT_ENCODE_SET);
         self.github.delete(&self.path(&format!("/{}", label)))
     }
 


### PR DESCRIPTION
This fixes errors removing labels with spaces in them that are described
in dbaron/wgmeeting-github-ircbot#40.

## What did you implement:

I implemented escaping of the label using `percent_encode` in roughly the same way as the existing use of `percent_encode` in `content.rs`, although using a different escaping setting (which I suspect may be important for labels with a "/" in them, although I didn't test that case).

#### How did you verify your change:

I compiled https://github.com/dbaron/wgmeeting-github-ircbot/ with a modified version of hubcaps (although applying this patch to the 0.5 release, since I didn't want to figure out the changes needed to upgrade my code to hubcaps master), and ran the test version to successfully remove the label in dbaron/wgmeeting-github-ircbot#40, which had previously failed with the failure described in https://github.com/dbaron/wgmeeting-github-ircbot/issues/40#issuecomment-577728948.

#### What (if anything) would need to be called out in the CHANGELOG for the next release:

Nothing, I think.