### PR TITLE
Statuses.target_url: optional

### DIFF
--- a/src/statuses.rs
+++ b/src/statuses.rs
@@ -60,7 +60,7 @@ pub struct Status {
     pub created_at: String,
     pub updated_at: String,
     pub state: State,
-    pub target_url: String,
+    pub target_url: Option<String>,
     pub description: String,
     pub id: u64,
     pub url: String,


### PR DESCRIPTION
## What did you implement:

GitHub commit statuses have an optional target_url now.

#### How did you verify your change:

Ran it in production :)

#### What (if anything) would need to be called out in the CHANGELOG for the next release:

Statuses.target_url is optional now.