### PR TITLE
add a description to labels

### DIFF
--- a/src/labels.rs
+++ b/src/labels.rs
@@ -56,17 +56,20 @@ impl Labels {
 pub struct LabelOptions {
     pub name: String,
     pub color: String,
+    pub description: String,
 }
 
 impl LabelOptions {
-    pub fn new<N, C>(name: N, color: C) -> LabelOptions
+    pub fn new<N, C, D>(name: N, color: C, description: D) -> LabelOptions
     where
         N: Into<String>,
         C: Into<String>,
+        D: Into<String>,
     {
         LabelOptions {
             name: name.into(),
             color: color.into(),
+            description: description.into(),
         }
     }
 }


### PR DESCRIPTION
Labels have a description field. This adds it.

#### How did you verify your change: I am using it locally.

#### What (if anything) would need to be called out in the CHANGELOG for the next release:
Labels now can create and modify the description field.