### PR TITLE
contents: add create and update methods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ pretty_env_logger = "0.3"
 tokio = "0.1"
 
 [dependencies]
+data-encoding = "2"
 dirs = { version = "2.0", optional = true }
 futures = "0.1"
 http = "0.1"


### PR DESCRIPTION
Signed-off-by: Jess Frazelle <jess@oxide.computer>

<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
2. This repository tries to stick with the community style conventions using [rustfmt](https://github.com/rust-lang-nursery/rustfmt#quick-start) with the *default* settings. If you have custom settings you may find that rustfmt
clutter the diff of your change with unrelated changes. Please apply formatting with `cargo  +nightly fmt` before submitting a pr.
-->

## What did you implement:

Added create and update methods for contents, happy to change any of the naming.
<!--
If this closes an open issue please replace xxx below with the issue number
-->


#### How did you verify your change:

using it on a project

#### What (if anything) would need to be called out in the CHANGELOG for the next release:

You can now create and update file contents.