### PR TITLE
remove error_chain dependency in favor of std::error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 0.6.0
 
-* BREAKING CHANGE: Migrate from old `futures` crate futures to std library futures making it possible to use `async`/`await` with this library. Please see the examples directory for updated examples of how to use these. [#254](https://github.com/softprops/hubcaps/pull/254)
+* BREAKING CHANGE: Migrate from old `futures` crate futures to std library futures making it possible to use `async`/`await` with this library. This puts this library in better compatibility with the current rust async ecosystem. Please see the examples directory for updated examples of how to use these. [#254](https://github.com/softprops/hubcaps/pull/254)
+* BREAKING CHANGE: replace `error_chain` derived errors with `std::error::Error` implementing `Error` enum. The motivation is that the error crate ecosystem is a moving target. The `std::error` package is not. This also makes for a smaller crate and smaller surface area. This moves away from errors of the form `Error(ErrorKind::Codec(_), _)` to errors of the form `Error::Codec(_)`
 * Add support for Content create and update apis [#253](https://github.com/softprops/hubcaps/pull/253)
 * Add description field to label apis [#252](https://github.com/softprops/hubcaps/pull/252)
 * Make status fields `created_at`, `updated_at` and `target_url` optional [#250](https://github.com/softprops/hubcaps/pull/250) [#249](https://github.com/softprops/hubcaps/pull/249)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ reqwest = { version = "0.10", default-features = false }
 serde = { version = "1.0.84", features = ['derive'] }
 serde_derive = "1.0"
 serde_json = "1.0"
-error-chain = "0.12"
 base64 = "0.12"
 percent-encoding = "2"
 

--- a/examples/assignees.rs
+++ b/examples/assignees.rs
@@ -1,35 +1,31 @@
+use hubcaps::{Credentials, Github};
 use std::env;
-
-use hubcaps::{Credentials, Github, Result};
+use std::error::Error;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> Result<(), Box<dyn Error>> {
     pretty_env_logger::init();
-    match env::var("GITHUB_TOKEN").ok() {
-        Some(token) => {
-            let github = Github::new(
-                concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
-                Credentials::Token(token),
-            )?;
-            let pull = github
-                .repo("softprops", "hubcaps")
-                .pulls()
-                .get(122)
-                .assignees()
-                .add(vec!["softprops"])
-                .await?;
-            println!("{:#?}", pull);
+    let token = env::var("GITHUB_TOKEN")?;
+    let github = Github::new(
+        concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
+        Credentials::Token(token),
+    )?;
+    let pull = github
+        .repo("softprops", "hubcaps")
+        .pulls()
+        .get(122)
+        .assignees()
+        .add(vec!["softprops"])
+        .await?;
+    println!("{:#?}", pull);
 
-            let issue = github
-                .repo("softprops", "hubcaps")
-                .issues()
-                .get(125)
-                .assignees()
-                .add(vec!["softprops"])
-                .await?;
-            println!("{:#?}", issue);
-            Ok(())
-        }
-        _ => Err("example missing GITHUB_TOKEN".into()),
-    }
+    let issue = github
+        .repo("softprops", "hubcaps")
+        .issues()
+        .get(125)
+        .assignees()
+        .add(vec!["softprops"])
+        .await?;
+    println!("{:#?}", issue);
+    Ok(())
 }

--- a/examples/branches.rs
+++ b/examples/branches.rs
@@ -1,63 +1,58 @@
-use std::env;
-
 use futures::prelude::*;
-
 use hubcaps::branches::Protection;
-use hubcaps::{Credentials, Github, Result};
+use hubcaps::{Credentials, Github};
+use std::env;
+use std::error::Error;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> Result<(), Box<dyn Error>> {
     pretty_env_logger::init();
-    match env::var("GITHUB_TOKEN").ok() {
-        Some(token) => {
-            let github = Github::new(
-                concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
-                Credentials::Token(token),
-            )?;
+    let token = env::var("GITHUB_TOKEN")?;
+    let github = Github::new(
+        concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
+        Credentials::Token(token),
+    )?;
 
-            if let Err(err) = github
-                .repo("softprops", "hubcaps")
-                .branches()
-                .iter()
-                .try_for_each(|branch| async move {
-                    println!("{:#?}", branch);
-                    Ok(())
-                })
-                .await
-            {
-                println!("err {:#?}", err)
-            }
-
-            match github
-                .repo("softprops", "hubcaps")
-                .branches()
-                .get("master")
-                .await
-            {
-                Ok(branch) => println!("{:#?}", branch),
-                Err(err) => println!("err {:#?}", err),
-            }
-
-            // protect master branch
-            match github
-                .repo("softprops", "hubcaps")
-                .branches()
-                .protection(
-                    "master",
-                    &Protection {
-                        required_status_checks: None,
-                        enforce_admins: false,
-                        required_pull_request_reviews: None,
-                        restrictions: None,
-                    },
-                )
-                .await
-            {
-                Ok(pro) => println!("{:#?}", pro),
-                Err(err) => println!("err {:#?}", err),
-            }
+    if let Err(err) = github
+        .repo("softprops", "hubcaps")
+        .branches()
+        .iter()
+        .try_for_each(|branch| async move {
+            println!("{:#?}", branch);
             Ok(())
-        }
-        _ => Err("example missing GITHUB_TOKEN".into()),
+        })
+        .await
+    {
+        println!("err {:#?}", err)
     }
+
+    match github
+        .repo("softprops", "hubcaps")
+        .branches()
+        .get("master")
+        .await
+    {
+        Ok(branch) => println!("{:#?}", branch),
+        Err(err) => println!("err {:#?}", err),
+    }
+
+    // protect master branch
+    match github
+        .repo("softprops", "hubcaps")
+        .branches()
+        .protection(
+            "master",
+            &Protection {
+                required_status_checks: None,
+                enforce_admins: false,
+                required_pull_request_reviews: None,
+                restrictions: None,
+            },
+        )
+        .await
+    {
+        Ok(pro) => println!("{:#?}", pro),
+        Err(err) => println!("err {:#?}", err),
+    }
+    Ok(())
 }

--- a/examples/checks.rs
+++ b/examples/checks.rs
@@ -1,31 +1,23 @@
-use std::env;
-use std::fs::File;
-use std::io::Read;
-
 use hubcaps::checks::{
     Action, Annotation, AnnotationLevel, CheckRunOptions, Conclusion, Image, Output,
 };
 use hubcaps::git::GetReferenceResponse;
-use hubcaps::{Credentials, Github, InstallationTokenGenerator, JWTCredentials, Result};
-
-fn var(name: &str) -> Result<String> {
-    if let Ok(v) = env::var(name) {
-        Ok(v)
-    } else {
-        Err(format!("example missing {}", name).into())
-    }
-}
+use hubcaps::{Credentials, Github, InstallationTokenGenerator, JWTCredentials};
+use std::env;
+use std::error::Error;
+use std::fs::File;
+use std::io::Read;
 
 const USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"));
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> Result<(), Box<dyn Error>> {
     pretty_env_logger::init();
-    let key_file = var("GH_APP_KEY")?;
-    let app_id = var("GH_APP_ID")?;
-    let user_name = var("GH_USERNAME")?;
-    let repo = var("GH_REPO")?;
-    let branch = var("GH_BRANCH")?;
+    let key_file = env::var("GH_APP_KEY")?;
+    let app_id = env::var("GH_APP_ID")?;
+    let user_name = env::var("GH_USERNAME")?;
+    let repo = env::var("GH_REPO")?;
+    let branch = env::var("GH_BRANCH")?;
 
     let mut key = Vec::new();
     File::open(&key_file)?.read_to_end(&mut key)?;

--- a/examples/collaborators.rs
+++ b/examples/collaborators.rs
@@ -1,53 +1,50 @@
-use hubcaps::{self, Credentials, Github, Result};
+use hubcaps::{self, Credentials, Github};
 use std::env;
+use std::error::Error;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> Result<(), Box<dyn Error>> {
     pretty_env_logger::init();
-    match env::var("GITHUB_TOKEN").ok() {
-        Some(token) => {
-            let github = Github::new(
-                concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
-                Credentials::Token(token),
-            )?;
+    let token = env::var("GITHUB_TOKEN")?;
+    let github = Github::new(
+        concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
+        Credentials::Token(token),
+    )?;
 
-            println!("My organizations:");
-            println!();
+    println!("My organizations:");
+    println!();
 
-            for org in github.orgs().list().await? {
-                println!("{}", org.login);
-                println!("=============");
-                println!("Repos:");
+    for org in github.orgs().list().await? {
+        println!("{}", org.login);
+        println!("=============");
+        println!("Repos:");
 
-                for repo in github
-                    .org_repos(&org.login[..])
-                    .list(&Default::default())
-                    .await?
-                {
-                    println!("* {}", repo.name);
+        for repo in github
+            .org_repos(&org.login[..])
+            .list(&Default::default())
+            .await?
+        {
+            println!("* {}", repo.name);
 
-                    // If you have push permissions on an org, you can list collaborators.
-                    // Otherwise, don't print them.
-                    if let Ok(collabs) = github
-                        .repo(&org.login[..], &repo.name[..])
-                        .collaborators()
-                        .list()
-                        .await
-                    {
-                        println!(
-                            "  * Collaborators: {}",
-                            collabs
-                                .into_iter()
-                                .map(|c| { c.login })
-                                .collect::<Vec<_>>()
-                                .join(", ")
-                        );
-                    }
-                }
-                println!()
+            // If you have push permissions on an org, you can list collaborators.
+            // Otherwise, don't print them.
+            if let Ok(collabs) = github
+                .repo(&org.login[..], &repo.name[..])
+                .collaborators()
+                .list()
+                .await
+            {
+                println!(
+                    "  * Collaborators: {}",
+                    collabs
+                        .into_iter()
+                        .map(|c| { c.login })
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                );
             }
-            Ok(())
         }
-        _ => Err("example missing GITHUB_TOKEN".into()),
+        println!()
     }
+    Ok(())
 }

--- a/examples/comments.rs
+++ b/examples/comments.rs
@@ -1,28 +1,25 @@
 use hubcaps::comments::CommentOptions;
-use hubcaps::{Credentials, Github, Result};
+use hubcaps::{Credentials, Github};
 use std::env;
+use std::error::Error;
 
 const USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"));
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> Result<(), Box<dyn Error>> {
     pretty_env_logger::init();
-    match env::var("GITHUB_TOKEN").ok() {
-        Some(token) => {
-            let github = Github::new(USER_AGENT, Credentials::Token(token))?;
+    let token = env::var("GITHUB_TOKEN")?;
+    let github = Github::new(USER_AGENT, Credentials::Token(token))?;
 
-            let issue = github.repo("softprops", "hubcat").issues().get(1);
-            let f = issue.comments().create(&CommentOptions {
-                body: format!("Hello, world!\n---\nSent by {}", USER_AGENT),
-            });
+    let issue = github.repo("softprops", "hubcat").issues().get(1);
+    let f = issue.comments().create(&CommentOptions {
+        body: format!("Hello, world!\n---\nSent by {}", USER_AGENT),
+    });
 
-            match f.await {
-                Ok(comment) => println!("{:?}", comment),
-                Err(err) => println!("err {}", err),
-            }
-
-            Ok(())
-        }
-        _ => Err("example missing GITHUB_TOKEN".into()),
+    match f.await {
+        Ok(comment) => println!("{:?}", comment),
+        Err(err) => println!("err {}", err),
     }
+
+    Ok(())
 }

--- a/examples/conditional_requests.rs
+++ b/examples/conditional_requests.rs
@@ -1,11 +1,11 @@
-use hubcaps::Result;
 #[cfg(feature = "httpcache")]
 use hubcaps::{Github, HttpCache};
 #[cfg(feature = "httpcache")]
 use reqwest::Client;
+use std::error::Error;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> Result<(), Box<dyn Error>> {
     pretty_env_logger::init();
 
     #[cfg(not(feature = "httpcache"))]

--- a/examples/content.rs
+++ b/examples/content.rs
@@ -1,42 +1,37 @@
+use futures::prelude::*;
+use hubcaps::{Credentials, Github};
 use std::env;
+use std::error::Error;
 use std::str;
 
-use futures::prelude::*;
-
-use hubcaps::{Credentials, Github, Result};
-
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> Result<(), Box<dyn Error>> {
     pretty_env_logger::init();
-    match env::var("GITHUB_TOKEN").ok() {
-        Some(token) => {
-            let github = Github::new(
-                concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
-                Credentials::Token(token),
-            )?;
+    let token = env::var("GITHUB_TOKEN")?;
+    let github = Github::new(
+        concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
+        Credentials::Token(token),
+    )?;
 
-            let repo = github.repo("softprops", "hubcaps");
+    let repo = github.repo("softprops", "hubcaps");
 
-            println!("License file:");
-            let license = repo.content().file("LICENSE").await?;
-            println!("{}", str::from_utf8(&license.content).unwrap());
+    println!("License file:");
+    let license = repo.content().file("LICENSE").await?;
+    println!("{}", str::from_utf8(&license.content).unwrap());
 
-            println!("Directory contents stream:");
-            repo.content()
-                .iter("/examples")
-                .try_for_each(|item| async move {
-                    println!("  {}", item.path);
-                    Ok(())
-                })
-                .await?;
-
-            println!("Root directory:");
-            for item in repo.content().root().try_collect::<Vec<_>>().await? {
-                println!("  {}", item.path)
-            }
-
+    println!("Directory contents stream:");
+    repo.content()
+        .iter("/examples")
+        .try_for_each(|item| async move {
+            println!("  {}", item.path);
             Ok(())
-        }
-        _ => Err("example missing GITHUB_TOKEN".into()),
+        })
+        .await?;
+
+    println!("Root directory:");
+    for item in repo.content().root().try_collect::<Vec<_>>().await? {
+        println!("  {}", item.path)
     }
+
+    Ok(())
 }

--- a/examples/deployments.rs
+++ b/examples/deployments.rs
@@ -1,8 +1,9 @@
-use hubcaps::{Credentials, Github, Result};
+use hubcaps::{Credentials, Github};
 use std::env;
+use std::error::Error;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> Result<(), Box<dyn Error>> {
     match env::var("GITHUB_TOKEN").ok() {
         Some(token) => {
             let github = Github::new(

--- a/examples/fork.rs
+++ b/examples/fork.rs
@@ -1,24 +1,21 @@
-use hubcaps::{Credentials, Github, Result};
+use hubcaps::{Credentials, Github};
 use std::env;
+use std::error::Error;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> Result<(), Box<dyn Error>> {
     pretty_env_logger::init();
-    match env::var("GITHUB_TOKEN").ok() {
-        Some(token) => {
-            let github = Github::new(
-                concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
-                Credentials::Token(token),
-            )?;
+    let token = env::var("GITHUB_TOKEN")?;
+    let github = Github::new(
+        concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
+        Credentials::Token(token),
+    )?;
 
-            let repo = github.repo("softprops", "hubcaps");
+    let repo = github.repo("softprops", "hubcaps");
 
-            let forked = repo.forks().create().await?;
+    let forked = repo.forks().create().await?;
 
-            println!("Forked repository to {}", forked.full_name);
+    println!("Forked repository to {}", forked.full_name);
 
-            Ok(())
-        }
-        _ => Err("example missing GITHUB_TOKEN".into()),
-    }
+    Ok(())
 }

--- a/examples/forks.rs
+++ b/examples/forks.rs
@@ -1,33 +1,30 @@
 use futures::prelude::*;
 use hubcaps::repositories::ForkListOptions;
-use hubcaps::{Credentials, Github, Result};
+use hubcaps::{Credentials, Github};
 use std::env;
+use std::error::Error;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> Result<(), Box<dyn Error>> {
     pretty_env_logger::init();
-    match env::var("GITHUB_TOKEN").ok() {
-        Some(token) => {
-            let github = Github::new(
-                concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
-                Credentials::Token(token),
-            )?;
-            let owner = "octokit";
-            let repo = "rest.js";
+    let token = env::var("GITHUB_TOKEN")?;
+    let github = Github::new(
+        concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
+        Credentials::Token(token),
+    )?;
+    let owner = "octokit";
+    let repo = "rest.js";
 
-            let options = ForkListOptions::builder().build();
-            github
-                .repo(owner, repo)
-                .forks()
-                .iter(&options)
-                .try_for_each(move |repo| async move {
-                    println!("{}", repo.full_name);
-                    Ok(())
-                })
-                .await?;
-
+    let options = ForkListOptions::builder().build();
+    github
+        .repo(owner, repo)
+        .forks()
+        .iter(&options)
+        .try_for_each(move |repo| async move {
+            println!("{}", repo.full_name);
             Ok(())
-        }
-        _ => Err("example missing GITHUB_TOKEN".into()),
-    }
+        })
+        .await?;
+
+    Ok(())
 }

--- a/examples/gists.rs
+++ b/examples/gists.rs
@@ -1,20 +1,17 @@
-use hubcaps::{Credentials, Github, Result};
+use hubcaps::{Credentials, Github};
 use std::env;
+use std::error::Error;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> Result<(), Box<dyn Error>> {
     pretty_env_logger::init();
-    match env::var("GITHUB_TOKEN").ok() {
-        Some(token) => {
-            let github = Github::new(
-                concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
-                Credentials::Token(token),
-            )?;
-            for gist in github.gists().list(&Default::default()).await? {
-                println!("{:#?}", gist)
-            }
-            Ok(())
-        }
-        _ => Err("example missing GITHUB_TOKEN".into()),
+    let token = env::var("GITHUB_TOKEN")?;
+    let github = Github::new(
+        concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
+        Credentials::Token(token),
+    )?;
+    for gist in github.gists().list(&Default::default()).await? {
+        println!("{:#?}", gist)
     }
+    Ok(())
 }

--- a/examples/gists_create.rs
+++ b/examples/gists_create.rs
@@ -1,50 +1,47 @@
 use hubcaps::gists::{Content, GistOptions};
-use hubcaps::{Credentials, Github, Result};
+use hubcaps::{Credentials, Github};
 use std::collections::HashMap;
 use std::env;
+use std::error::Error;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> Result<(), Box<dyn Error>> {
     pretty_env_logger::init();
-    match env::var("GITHUB_TOKEN").ok() {
-        Some(token) => {
-            let github = Github::new(
-                concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
-                Credentials::Token(token),
-            )?;
+    let token = env::var("GITHUB_TOKEN")?;
+    let github = Github::new(
+        concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
+        Credentials::Token(token),
+    )?;
 
-            // create new gist
-            let mut files = HashMap::new();
-            files.insert("file1", "Hello World");
-            let options = GistOptions::new(Some("gist description"), false, files);
-            let gist = github.gists().create(&options).await?;
-            println!("{:#?}", gist);
+    // create new gist
+    let mut files = HashMap::new();
+    files.insert("file1", "Hello World");
+    let options = GistOptions::new(Some("gist description"), false, files);
+    let gist = github.gists().create(&options).await?;
+    println!("{:#?}", gist);
 
-            // edit file1
-            let mut files = HashMap::new();
-            files.insert("file1", "Hello World!!");
-            let options = GistOptions::new(None as Option<String>, false, files);
-            let gist = github.gists().edit(&gist.id, &options).await?;
-            println!("{:#?}", gist);
+    // edit file1
+    let mut files = HashMap::new();
+    files.insert("file1", "Hello World!!");
+    let options = GistOptions::new(None as Option<String>, false, files);
+    let gist = github.gists().edit(&gist.id, &options).await?;
+    println!("{:#?}", gist);
 
-            // rename file1 to file2
-            let mut files = HashMap::new();
-            files.insert(
-                String::from("file1"),
-                Content::new(Some("file2"), "Hello World!!"),
-            );
-            let options = GistOptions {
-                description: None as Option<String>,
-                public: None,
-                files,
-            };
-            let gist = github.gists().edit(&gist.id, &options).await?;
-            println!("{:#?}", gist);
+    // rename file1 to file2
+    let mut files = HashMap::new();
+    files.insert(
+        String::from("file1"),
+        Content::new(Some("file2"), "Hello World!!"),
+    );
+    let options = GistOptions {
+        description: None as Option<String>,
+        public: None,
+        files,
+    };
+    let gist = github.gists().edit(&gist.id, &options).await?;
+    println!("{:#?}", gist);
 
-            // delete gist
-            github.gists().delete(&gist.id).await?;
-            Ok(())
-        }
-        _ => Err("example missing GITHUB_TOKEN".into()),
-    }
+    // delete gist
+    github.gists().delete(&gist.id).await?;
+    Ok(())
 }

--- a/examples/git.rs
+++ b/examples/git.rs
@@ -1,33 +1,30 @@
-use hubcaps::{Credentials, Github, Result};
+use hubcaps::{Credentials, Github};
 use std::env;
+use std::error::Error;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> Result<(), Box<dyn Error>> {
     pretty_env_logger::init();
-    match env::var("GITHUB_TOKEN").ok() {
-        Some(token) => {
-            let github = Github::new(
-                concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
-                Credentials::Token(token),
-            )?;
-            if let Some(file) = github
-                .repo("softprops", "hubcaps")
-                .git()
-                .tree("master", true)
-                .await?
-                .tree
-                .iter()
-                .find(|file| file.path == "README.md")
-            {
-                let blob = github
-                    .repo("softprops", "hubcaps")
-                    .git()
-                    .blob(file.sha.clone())
-                    .await?;
-                println!("readme {:#?}", blob);
-            }
-            Ok(())
-        }
-        _ => Err("example missing GITHUB_TOKEN".into()),
+    let token = env::var("GITHUB_TOKEN")?;
+    let github = Github::new(
+        concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
+        Credentials::Token(token),
+    )?;
+    if let Some(file) = github
+        .repo("softprops", "hubcaps")
+        .git()
+        .tree("master", true)
+        .await?
+        .tree
+        .iter()
+        .find(|file| file.path == "README.md")
+    {
+        let blob = github
+            .repo("softprops", "hubcaps")
+            .git()
+            .blob(file.sha.clone())
+            .await?;
+        println!("readme {:#?}", blob);
     }
+    Ok(())
 }

--- a/examples/hooks.rs
+++ b/examples/hooks.rs
@@ -1,33 +1,30 @@
 use hubcaps::hooks::{HookCreateOptions, WebHookContentType};
-use hubcaps::{Credentials, Github, Result};
+use hubcaps::{Credentials, Github};
 use std::env;
+use std::error::Error;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> Result<(), Box<dyn Error>> {
     pretty_env_logger::init();
-    match env::var("GITHUB_TOKEN").ok() {
-        Some(token) => {
-            let github = Github::new(
-                concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
-                Credentials::Token(token),
-            )?;
-            let repo = github.repo("softprops", "hubcaps");
-            let hook = repo
-                .hooks()
-                .create(
-                    &HookCreateOptions::web()
-                        .url("http://localhost:8080")
-                        .content_type(WebHookContentType::Json)
-                        .build(),
-                )
-                .await;
-            println!("{:#?}", hook);
-            let hooks = repo.hooks();
-            for hook in hooks.list().await? {
-                println!("{:#?}", hook)
-            }
-            Ok(())
-        }
-        _ => Err("example missing GITHUB_TOKEN".into()),
+    let token = env::var("GITHUB_TOKEN")?;
+    let github = Github::new(
+        concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
+        Credentials::Token(token),
+    )?;
+    let repo = github.repo("softprops", "hubcaps");
+    let hook = repo
+        .hooks()
+        .create(
+            &HookCreateOptions::web()
+                .url("http://localhost:8080")
+                .content_type(WebHookContentType::Json)
+                .build(),
+        )
+        .await;
+    println!("{:#?}", hook);
+    let hooks = repo.hooks();
+    for hook in hooks.list().await? {
+        println!("{:#?}", hook)
     }
+    Ok(())
 }

--- a/examples/invitations.rs
+++ b/examples/invitations.rs
@@ -1,25 +1,18 @@
 use futures::prelude::*;
-use hubcaps::{Credentials, Github, InstallationTokenGenerator, JWTCredentials, Result};
+use hubcaps::{Credentials, Github, InstallationTokenGenerator, JWTCredentials};
 use std::env;
+use std::error::Error;
 use std::fs::File;
 use std::io::Read;
-
-fn var(name: &str) -> Result<String> {
-    if let Ok(v) = env::var(name) {
-        Ok(v)
-    } else {
-        Err(format!("example missing {}", name).into())
-    }
-}
 
 const USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"));
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> Result<(), Box<dyn Error>> {
     pretty_env_logger::init();
-    let key_file = var("GH_APP_KEY")?;
-    let app_id = var("GH_APP_ID")?;
-    let installation_id = var("GH_INSTALL_ID")?;
+    let key_file = env::var("GH_APP_KEY")?;
+    let app_id = env::var("GH_APP_ID")?;
+    let installation_id = env::var("GH_INSTALL_ID")?;
 
     let mut key = Vec::new();
     File::open(&key_file)?.read_to_end(&mut key)?;

--- a/examples/issues.rs
+++ b/examples/issues.rs
@@ -1,33 +1,30 @@
 use futures::prelude::*;
 use hubcaps::issues::{IssueListOptions, State};
-use hubcaps::{Credentials, Github, Result};
+use hubcaps::{Credentials, Github};
 use std::env;
+use std::error::Error;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> Result<(), Box<dyn Error>> {
     pretty_env_logger::init();
-    match env::var("GITHUB_TOKEN").ok() {
-        Some(token) => {
-            let github = Github::new(
-                concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
-                Credentials::Token(token),
-            )?;
-            github
-                .repo("matthiasbeyer", "imag")
-                .issues()
-                .iter(
-                    &IssueListOptions::builder()
-                        .per_page(100)
-                        .state(State::All)
-                        .build(),
-                )
-                .try_for_each(move |issue| async move {
-                    println!("{} ({})", issue.title, issue.state);
-                    Ok(())
-                })
-                .await?;
+    let token = env::var("GITHUB_TOKEN")?;
+    let github = Github::new(
+        concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
+        Credentials::Token(token),
+    )?;
+    github
+        .repo("matthiasbeyer", "imag")
+        .issues()
+        .iter(
+            &IssueListOptions::builder()
+                .per_page(100)
+                .state(State::All)
+                .build(),
+        )
+        .try_for_each(move |issue| async move {
+            println!("{} ({})", issue.title, issue.state);
             Ok(())
-        }
-        _ => Err("example missing GITHUB_TOKEN".into()),
-    }
+        })
+        .await?;
+    Ok(())
 }

--- a/examples/labels.rs
+++ b/examples/labels.rs
@@ -1,39 +1,36 @@
 use futures::prelude::*;
-use hubcaps::{Credentials, Github, Result};
+use hubcaps::{Credentials, Github};
 use std::env;
+use std::error::Error;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> Result<(), Box<dyn Error>> {
     pretty_env_logger::init();
-    match env::var("GITHUB_TOKEN").ok() {
-        Some(token) => {
-            let github = Github::new(
-                concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
-                Credentials::Token(token),
-            )?;
-            // add labels associated with a pull
-            println!(
-                "{:#?}",
-                github
-                    .repo("softprops", "hubcaps")
-                    .pulls()
-                    .get(121)
-                    .labels()
-                    .add(vec!["enhancement"])
-                    .await?
-            );
-            // stream over all labels defined for a repo
-            github
-                .repo("rust-lang", "cargo")
-                .labels()
-                .iter()
-                .try_for_each(move |label| async move {
-                    println!("{}", label.name);
-                    Ok(())
-                })
-                .await?;
+    let token = env::var("GITHUB_TOKEN")?;
+    let github = Github::new(
+        concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
+        Credentials::Token(token),
+    )?;
+    // add labels associated with a pull
+    println!(
+        "{:#?}",
+        github
+            .repo("softprops", "hubcaps")
+            .pulls()
+            .get(121)
+            .labels()
+            .add(vec!["enhancement"])
+            .await?
+    );
+    // stream over all labels defined for a repo
+    github
+        .repo("rust-lang", "cargo")
+        .labels()
+        .iter()
+        .try_for_each(move |label| async move {
+            println!("{}", label.name);
             Ok(())
-        }
-        _ => Err("example missing GITHUB_TOKEN".into()),
-    }
+        })
+        .await?;
+    Ok(())
 }

--- a/examples/notifications.rs
+++ b/examples/notifications.rs
@@ -1,35 +1,32 @@
 use hubcaps::notifications::ThreadListOptions;
-use hubcaps::{Credentials, Github, Result};
+use hubcaps::{Credentials, Github};
 use std::env;
+use std::error::Error;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> Result<(), Box<dyn Error>> {
     pretty_env_logger::init();
-    match env::var("GITHUB_TOKEN").ok() {
-        Some(token) => {
-            let github = Github::new(
-                concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
-                Credentials::Token(token),
-            )?;
+    let token = env::var("GITHUB_TOKEN")?;
+    let github = Github::new(
+        concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
+        Credentials::Token(token),
+    )?;
 
-            let opts = ThreadListOptions::builder().all(true).build();
-            for thread in github.activity().notifications().list(&opts).await? {
-                println!("{:#?}", thread);
-                let subscription = github
-                    .activity()
-                    .notifications()
-                    .get_subscription(thread.id)
-                    .await;
-                if let Ok(sub) = subscription {
-                    println!("{:#?}", sub);
-                }
-            }
-
-            // Mark all notifications as read.
-            github.activity().notifications().mark_as_read(None).await?;
-
-            Ok(())
+    let opts = ThreadListOptions::builder().all(true).build();
+    for thread in github.activity().notifications().list(&opts).await? {
+        println!("{:#?}", thread);
+        let subscription = github
+            .activity()
+            .notifications()
+            .get_subscription(thread.id)
+            .await;
+        if let Ok(sub) = subscription {
+            println!("{:#?}", sub);
         }
-        _ => Err("example missing GITHUB_TOKEN".into()),
     }
+
+    // Mark all notifications as read.
+    github.activity().notifications().mark_as_read(None).await?;
+
+    Ok(())
 }

--- a/examples/orgs.rs
+++ b/examples/orgs.rs
@@ -1,42 +1,39 @@
 use hubcaps::repositories::{OrgRepoType, OrganizationRepoListOptions};
-use hubcaps::{Credentials, Github, Result};
+use hubcaps::{Credentials, Github};
 use std::env;
+use std::error::Error;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> Result<(), Box<dyn Error>> {
     pretty_env_logger::init();
-    match env::var("GITHUB_TOKEN").ok() {
-        Some(token) => {
-            let github = Github::new(
-                concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
-                Credentials::Token(token),
-            )?;
+    let token = env::var("GITHUB_TOKEN")?;
+    let github = Github::new(
+        concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
+        Credentials::Token(token),
+    )?;
 
-            let options = OrganizationRepoListOptions::builder()
-                .repo_type(OrgRepoType::Forks)
-                .build();
+    let options = OrganizationRepoListOptions::builder()
+        .repo_type(OrgRepoType::Forks)
+        .build();
 
-            println!("Forks in the rust-lang organization:");
+    println!("Forks in the rust-lang organization:");
 
-            for repo in github.org_repos("rust-lang").list(&options).await? {
-                println!("{}", repo.name)
-            }
-
-            println!();
-
-            println!("My organizations:");
-            for org in github.orgs().list().await? {
-                println!("{}", org.login)
-            }
-
-            println!();
-
-            println!("softprops' organizations:");
-            for org in github.user_orgs("softprops").list().await? {
-                println!("{}", org.login)
-            }
-            Ok(())
-        }
-        _ => Err("example missing GITHUB_TOKEN".into()),
+    for repo in github.org_repos("rust-lang").list(&options).await? {
+        println!("{}", repo.name)
     }
+
+    println!();
+
+    println!("My organizations:");
+    for org in github.orgs().list().await? {
+        println!("{}", org.login)
+    }
+
+    println!();
+
+    println!("softprops' organizations:");
+    for org in github.user_orgs("softprops").list().await? {
+        println!("{}", org.login)
+    }
+    Ok(())
 }

--- a/examples/pull_files.rs
+++ b/examples/pull_files.rs
@@ -1,26 +1,23 @@
-use hubcaps::{Credentials, Github, Result};
+use hubcaps::{Credentials, Github};
 use std::env;
+use std::error::Error;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> Result<(), Box<dyn Error>> {
     pretty_env_logger::init();
-    match env::var("GITHUB_TOKEN").ok() {
-        Some(token) => {
-            let github = Github::new(
-                concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
-                Credentials::Token(token),
-            )?;
-            for diff in github
-                .repo("rust-lang", "rust")
-                .pulls()
-                .get(49536)
-                .files()
-                .await?
-            {
-                println!("{:#?}", diff);
-            }
-            Ok(())
-        }
-        _ => Err("example missing GITHUB_TOKEN".into()),
+    let token = env::var("GITHUB_TOKEN")?;
+    let github = Github::new(
+        concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
+        Credentials::Token(token),
+    )?;
+    for diff in github
+        .repo("rust-lang", "rust")
+        .pulls()
+        .get(49536)
+        .files()
+        .await?
+    {
+        println!("{:#?}", diff);
     }
+    Ok(())
 }

--- a/examples/pulls.rs
+++ b/examples/pulls.rs
@@ -1,64 +1,61 @@
 use futures::prelude::*;
-use hubcaps::{Credentials, Github, Result};
+use hubcaps::{Credentials, Github};
 use std::env;
+use std::error::Error;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> Result<(), Box<dyn Error>> {
     pretty_env_logger::init();
-    match env::var("GITHUB_TOKEN").ok() {
-        Some(token) => {
-            let github = Github::new(
-                concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
-                Credentials::Token(token),
-            )?;
-            let repo = github.repo("softprops", "hubcat");
-            let pulls = repo.pulls();
-            pulls
-                .iter(&Default::default())
-                .try_for_each(|pull| async move {
-                    println!("{:#?}", pull);
-                    Ok(())
-                })
-                .await?;
-
-            println!("comments");
-            for c in github
-                .repo("softprops", "hubcaps")
-                .pulls()
-                .get(28)
-                .comments()
-                .list(&Default::default())
-                .await?
-            {
-                println!("{:#?}", c);
-            }
-
-            println!("commits");
-            github
-                .repo("softprops", "hubcaps")
-                .pulls()
-                .get(28)
-                .commits()
-                .iter()
-                .try_for_each(|c| async move {
-                    println!("{:#?}", c);
-                    Ok(())
-                })
-                .await?;
-
-            println!("review requests");
-            println!(
-                "{:#?}",
-                github
-                    .repo("softprops", "hubcaps")
-                    .pulls()
-                    .get(190)
-                    .review_requests()
-                    .get()
-                    .await?
-            );
+    let token = env::var("GITHUB_TOKEN")?;
+    let github = Github::new(
+        concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
+        Credentials::Token(token),
+    )?;
+    let repo = github.repo("softprops", "hubcat");
+    let pulls = repo.pulls();
+    pulls
+        .iter(&Default::default())
+        .try_for_each(|pull| async move {
+            println!("{:#?}", pull);
             Ok(())
-        }
-        _ => Err("example missing GITHUB_TOKEN".into()),
+        })
+        .await?;
+
+    println!("comments");
+    for c in github
+        .repo("softprops", "hubcaps")
+        .pulls()
+        .get(28)
+        .comments()
+        .list(&Default::default())
+        .await?
+    {
+        println!("{:#?}", c);
     }
+
+    println!("commits");
+    github
+        .repo("softprops", "hubcaps")
+        .pulls()
+        .get(28)
+        .commits()
+        .iter()
+        .try_for_each(|c| async move {
+            println!("{:#?}", c);
+            Ok(())
+        })
+        .await?;
+
+    println!("review requests");
+    println!(
+        "{:#?}",
+        github
+            .repo("softprops", "hubcaps")
+            .pulls()
+            .get(190)
+            .review_requests()
+            .get()
+            .await?
+    );
+    Ok(())
 }

--- a/examples/redir.rs
+++ b/examples/redir.rs
@@ -1,18 +1,15 @@
-use hubcaps::{Credentials, Github, Result};
+use hubcaps::{Credentials, Github};
 use std::env;
+use std::error::Error;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> Result<(), Box<dyn Error>> {
     pretty_env_logger::init();
-    match env::var("GITHUB_TOKEN").ok() {
-        Some(token) => {
-            let github = Github::new(
-                concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
-                Credentials::Token(token),
-            )?;
-            github.activity().stars().star("rust-lang", "log").await?;
-            Ok(())
-        }
-        _ => Err("example missing GITHUB_TOKEN".into()),
-    }
+    let token = env::var("GITHUB_TOKEN")?;
+    let github = Github::new(
+        concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
+        Credentials::Token(token),
+    )?;
+    github.activity().stars().star("rust-lang", "log").await?;
+    Ok(())
 }

--- a/examples/releases.rs
+++ b/examples/releases.rs
@@ -1,34 +1,31 @@
-use hubcaps::{Credentials, Github, Result};
+use hubcaps::{Credentials, Github};
 use std::env;
+use std::error::Error;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> Result<(), Box<dyn Error>> {
     pretty_env_logger::init();
-    match env::var("GITHUB_TOKEN").ok() {
-        Some(token) => {
-            let github = Github::new(
-                concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
-                Credentials::Token(token),
-            )?;
-            let owner = "octokit";
-            let repo = "rest.js";
+    let token = env::var("GITHUB_TOKEN")?;
+    let github = Github::new(
+        concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
+        Credentials::Token(token),
+    )?;
+    let owner = "octokit";
+    let repo = "rest.js";
 
-            for r in github.repo(owner, repo).releases().list().await? {
-                println!("{:#?}", r.name);
-            }
-
-            let latest = github.repo(owner, repo).releases().latest().await?;
-            println!("{:#?}", latest);
-
-            let release = github
-                .repo(owner, repo)
-                .releases()
-                .by_tag("v11.0.0")
-                .await?;
-            println!("{:#?}", release);
-
-            Ok(())
-        }
-        _ => Err("example missing GITHUB_TOKEN".into()),
+    for r in github.repo(owner, repo).releases().list().await? {
+        println!("{:#?}", r.name);
     }
+
+    let latest = github.repo(owner, repo).releases().latest().await?;
+    println!("{:#?}", latest);
+
+    let release = github
+        .repo(owner, repo)
+        .releases()
+        .by_tag("v11.0.0")
+        .await?;
+    println!("{:#?}", release);
+
+    Ok(())
 }

--- a/examples/repos.rs
+++ b/examples/repos.rs
@@ -1,32 +1,29 @@
 use futures::prelude::*;
-use hubcaps::{Credentials, Github, Result};
+use hubcaps::{Credentials, Github};
 use std::env;
+use std::error::Error;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> Result<(), Box<dyn Error>> {
     pretty_env_logger::init();
-    match env::var("GITHUB_TOKEN").ok() {
-        Some(token) => {
-            let github = &Github::new(
-                concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
-                Credentials::Token(token),
-            )?;
-            github
-                .user_repos("softprops")
-                .iter(&Default::default())
-                .try_for_each(move |repo| async move {
-                    println!("{}", repo.name);
-                    let f = repo.languages(github.clone()).map_ok(|langs| {
-                        for (language, bytes_of_code) in langs {
-                            println!("{}: {} bytes", language, bytes_of_code)
-                        }
-                    });
-                    tokio::spawn(f.map(|_| ()));
-                    Ok(())
-                })
-                .await?;
+    let token = env::var("GITHUB_TOKEN")?;
+    let github = &Github::new(
+        concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
+        Credentials::Token(token),
+    )?;
+    github
+        .user_repos("softprops")
+        .iter(&Default::default())
+        .try_for_each(move |repo| async move {
+            println!("{}", repo.name);
+            let f = repo.languages(github.clone()).map_ok(|langs| {
+                for (language, bytes_of_code) in langs {
+                    println!("{}: {} bytes", language, bytes_of_code)
+                }
+            });
+            tokio::spawn(f.map(|_| ()));
             Ok(())
-        }
-        _ => Err("example missing GITHUB_TOKEN".into()),
-    }
+        })
+        .await?;
+    Ok(())
 }

--- a/examples/search_issues.rs
+++ b/examples/search_issues.rs
@@ -1,33 +1,30 @@
 use futures::prelude::*;
 use hubcaps::search::SearchIssuesOptions;
-use hubcaps::{Credentials, Github, Result};
+use hubcaps::{Credentials, Github};
 use std::env;
+use std::error::Error;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> Result<(), Box<dyn Error>> {
     pretty_env_logger::init();
-    match env::var("GITHUB_TOKEN").ok() {
-        Some(token) => {
-            let github = Github::new(
-                concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
-                Credentials::Token(token),
-            )?;
-            println!("issue search results");
-            // https://developer.github.com/v3/search/#parameters-3
-            github
-                .search()
-                .issues()
-                .iter(
-                    "user:softprops",
-                    &SearchIssuesOptions::builder().per_page(100).build(),
-                )
-                .try_for_each(|issue| async move {
-                    println!("{}", issue.title);
-                    Ok(())
-                })
-                .await?;
+    let token = env::var("GITHUB_TOKEN")?;
+    let github = Github::new(
+        concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
+        Credentials::Token(token),
+    )?;
+    println!("issue search results");
+    // https://developer.github.com/v3/search/#parameters-3
+    github
+        .search()
+        .issues()
+        .iter(
+            "user:softprops",
+            &SearchIssuesOptions::builder().per_page(100).build(),
+        )
+        .try_for_each(|issue| async move {
+            println!("{}", issue.title);
             Ok(())
-        }
-        _ => Err("example missing GITHUB_TOKEN".into()),
-    }
+        })
+        .await?;
+    Ok(())
 }

--- a/examples/search_repos.rs
+++ b/examples/search_repos.rs
@@ -1,33 +1,30 @@
 use futures::prelude::*;
 use hubcaps::search::SearchReposOptions;
-use hubcaps::{Credentials, Github, Result};
+use hubcaps::{Credentials, Github};
 use std::env;
+use std::error::Error;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> Result<(), Box<dyn Error>> {
     pretty_env_logger::init();
-    match env::var("GITHUB_TOKEN").ok() {
-        Some(token) => {
-            let github = Github::new(
-                concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
-                Credentials::Token(token),
-            )?;
-            println!("repo search results");
-            // https://developer.github.com/v3/search/#parameters
-            github
-                .search()
-                .repos()
-                .iter(
-                    "user:softprops hubcaps",
-                    &SearchReposOptions::builder().per_page(100).build(),
-                )
-                .try_for_each(|repo| async move {
-                    println!("{}", repo.full_name);
-                    Ok(())
-                })
-                .await?;
+    let token = env::var("GITHUB_TOKEN")?;
+    let github = Github::new(
+        concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
+        Credentials::Token(token),
+    )?;
+    println!("repo search results");
+    // https://developer.github.com/v3/search/#parameters
+    github
+        .search()
+        .repos()
+        .iter(
+            "user:softprops hubcaps",
+            &SearchReposOptions::builder().per_page(100).build(),
+        )
+        .try_for_each(|repo| async move {
+            println!("{}", repo.full_name);
             Ok(())
-        }
-        _ => Err("example missing GITHUB_TOKEN".into()),
-    }
+        })
+        .await?;
+    Ok(())
 }

--- a/examples/stars.rs
+++ b/examples/stars.rs
@@ -1,26 +1,23 @@
-use hubcaps::{Credentials, Github, Result};
+use hubcaps::{Credentials, Github};
 use std::env;
+use std::error::Error;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> Result<(), Box<dyn Error>> {
     pretty_env_logger::init();
-    match env::var("GITHUB_TOKEN").ok() {
-        Some(token) => {
-            let github = Github::new(
-                concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
-                Credentials::Token(token),
-            )?;
-            let stars = github.activity().stars();
-            let f = futures::future::try_join(
-                stars.star("softprops", "hubcaps"),
-                stars.is_starred("softprops", "hubcaps"),
-            );
-            match f.await {
-                Ok((_, starred)) => println!("starred? {:?}", starred),
-                Err(err) => println!("err {}", err),
-            }
-            Ok(())
-        }
-        _ => Err("example missing GITHUB_TOKEN".into()),
+    let token = env::var("GITHUB_TOKEN")?;
+    let github = Github::new(
+        concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
+        Credentials::Token(token),
+    )?;
+    let stars = github.activity().stars();
+    let f = futures::future::try_join(
+        stars.star("softprops", "hubcaps"),
+        stars.is_starred("softprops", "hubcaps"),
+    );
+    match f.await {
+        Ok((_, starred)) => println!("starred? {:?}", starred),
+        Err(err) => println!("err {}", err),
     }
+    Ok(())
 }

--- a/examples/teams.rs
+++ b/examples/teams.rs
@@ -1,96 +1,93 @@
 use futures::prelude::*;
 use hubcaps::teams::{TeamMemberOptions, TeamMemberRole, TeamOptions};
-use hubcaps::{Credentials, Github, Result};
+use hubcaps::{Credentials, Github};
 use std::env;
+use std::error::Error;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> Result<(), Box<dyn Error>> {
     pretty_env_logger::init();
-    match env::var("GITHUB_TOKEN").ok() {
-        Some(token) => {
-            let github = Github::new(
-                concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
-                Credentials::Token(token),
-            )?;
+    let token = env::var("GITHUB_TOKEN")?;
+    let github = Github::new(
+        concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
+        Credentials::Token(token),
+    )?;
 
-            let org = "eb6cb83a-cf75-4e88-a11a-ce117467d8ae";
-            let repo_name = "d18e3679-9830-40a9-8cf5-16602639b43e";
+    let org = "eb6cb83a-cf75-4e88-a11a-ce117467d8ae";
+    let repo_name = "d18e3679-9830-40a9-8cf5-16602639b43e";
 
-            println!("org teams");
-            github
-                .org(org)
-                .teams()
-                .iter()
-                .try_for_each(|team| async move {
-                    println!("{:#?}", team);
-                    Ok(())
-                })
-                .await?;
-
-            println!("repo teams");
-            github
-                .repo(org, repo_name)
-                .teams()
-                .iter()
-                .try_for_each(|team| async move {
-                    println!("{:#?}", team);
-                    Ok(())
-                })
-                .await?;
-
-            let new_team = github
-                .org(org)
-                .teams()
-                .create(&TeamOptions {
-                    name: String::from("hi"),
-                    description: Some(String::from("there")),
-                    permission: None,
-                    privacy: Some(String::from("secret")),
-                })
-                .await?;
-            println!("Created team: {:#?}", new_team);
-
-            let team = github.org(org).teams().get(new_team.id);
-
-            let updated_team = team
-                .update(&TeamOptions {
-                    name: String::from("hello"),
-                    description: None,
-                    permission: None,
-                    privacy: None,
-                })
-                .await?;
-            println!("Updated team: {:#?}", updated_team);
-
-            println!(
-                "Adding grahamc to the team: {:#?}",
-                team.add_user(
-                    "grahamc",
-                    TeamMemberOptions {
-                        role: TeamMemberRole::Member,
-                    }
-                )
-                .await?
-            );
-
-            println!("members:");
-            team.iter_members()
-                .try_for_each(|member| async move {
-                    println!("{:#?}", member);
-                    Ok(())
-                })
-                .await?;
-
-            println!(
-                "Removing grahamc from the team: {:#?}",
-                team.remove_user("grahamc").await?
-            );
-
-            let deleted_team = team.delete().await?;
-            println!("Deleted team: {:#?}", deleted_team);
-
+    println!("org teams");
+    github
+        .org(org)
+        .teams()
+        .iter()
+        .try_for_each(|team| async move {
+            println!("{:#?}", team);
             Ok(())
-        }
-        _ => Err("example missing GITHUB_TOKEN".into()),
-    }
+        })
+        .await?;
+
+    println!("repo teams");
+    github
+        .repo(org, repo_name)
+        .teams()
+        .iter()
+        .try_for_each(|team| async move {
+            println!("{:#?}", team);
+            Ok(())
+        })
+        .await?;
+
+    let new_team = github
+        .org(org)
+        .teams()
+        .create(&TeamOptions {
+            name: String::from("hi"),
+            description: Some(String::from("there")),
+            permission: None,
+            privacy: Some(String::from("secret")),
+        })
+        .await?;
+    println!("Created team: {:#?}", new_team);
+
+    let team = github.org(org).teams().get(new_team.id);
+
+    let updated_team = team
+        .update(&TeamOptions {
+            name: String::from("hello"),
+            description: None,
+            permission: None,
+            privacy: None,
+        })
+        .await?;
+    println!("Updated team: {:#?}", updated_team);
+
+    println!(
+        "Adding grahamc to the team: {:#?}",
+        team.add_user(
+            "grahamc",
+            TeamMemberOptions {
+                role: TeamMemberRole::Member,
+            }
+        )
+        .await?
+    );
+
+    println!("members:");
+    team.iter_members()
+        .try_for_each(|member| async move {
+            println!("{:#?}", member);
+            Ok(())
+        })
+        .await?;
+
+    println!(
+        "Removing grahamc from the team: {:#?}",
+        team.remove_user("grahamc").await?
+    );
+
+    let deleted_team = team.delete().await?;
+    println!("Deleted team: {:#?}", deleted_team);
+
+    Ok(())
 }

--- a/examples/traffic.rs
+++ b/examples/traffic.rs
@@ -1,46 +1,43 @@
 use hubcaps::traffic::TimeUnit;
-use hubcaps::{Credentials, Github, Result};
+use hubcaps::{Credentials, Github};
 use std::env;
+use std::error::Error;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> Result<(), Box<dyn Error>> {
     pretty_env_logger::init();
-    match env::var("GITHUB_TOKEN").ok() {
-        Some(token) => {
-            let github = Github::new(
-                concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
-                Credentials::Token(token),
-            )?;
-            let owner = "softprops";
-            let repo = "hubcaps";
+    let token = env::var("GITHUB_TOKEN")?;
+    let github = Github::new(
+        concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
+        Credentials::Token(token),
+    )?;
+    let owner = "softprops";
+    let repo = "hubcaps";
 
-            println!("Top 10 referrers");
-            for referrer in github.repo(owner, repo).traffic().referrers().await? {
-                println!("{:#?}", referrer)
-            }
-
-            println!("Top 10 paths");
-            for path in github.repo(owner, repo).traffic().paths().await? {
-                println!("{:#?}", path)
-            }
-
-            println!("Views per day");
-            let views = github
-                .repo(owner, repo)
-                .traffic()
-                .views(TimeUnit::Day)
-                .await?;
-            println!("{:#?}", views);
-
-            println!("Clones per day");
-            let clones = github
-                .repo(owner, repo)
-                .traffic()
-                .clones(TimeUnit::Day)
-                .await?;
-            println!("{:#?}", clones);
-            Ok(())
-        }
-        _ => Err("example missing GITHUB_TOKEN".into()),
+    println!("Top 10 referrers");
+    for referrer in github.repo(owner, repo).traffic().referrers().await? {
+        println!("{:#?}", referrer)
     }
+
+    println!("Top 10 paths");
+    for path in github.repo(owner, repo).traffic().paths().await? {
+        println!("{:#?}", path)
+    }
+
+    println!("Views per day");
+    let views = github
+        .repo(owner, repo)
+        .traffic()
+        .views(TimeUnit::Day)
+        .await?;
+    println!("{:#?}", views);
+
+    println!("Clones per day");
+    let clones = github
+        .repo(owner, repo)
+        .traffic()
+        .clones(TimeUnit::Day)
+        .await?;
+    println!("{:#?}", clones);
+    Ok(())
 }

--- a/examples/users.rs
+++ b/examples/users.rs
@@ -1,34 +1,31 @@
-use hubcaps::{Credentials, Github, Result};
+use hubcaps::{Credentials, Github};
 use std::env;
+use std::error::Error;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> Result<(), Box<dyn Error>> {
     pretty_env_logger::init();
-    match env::var("GITHUB_TOKEN").ok() {
-        Some(token) => {
-            let github = Github::new(
-                concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
-                Credentials::Token(token),
-            )?;
-            match github.users().authenticated().await {
-                Ok(me) => println!("{:#?}", me),
-                Err(err) => println!("err {:#?}", err),
-            }
-
-            match github
-                .users()
-                .get(
-                    env::var("GH_USERNAME")
-                        .ok()
-                        .unwrap_or_else(|| "bors".into()),
-                )
-                .await
-            {
-                Ok(user) => println!("{:#?}", user),
-                Err(err) => println!("err {:#?}", err),
-            }
-            Ok(())
-        }
-        _ => Err("example missing GITHUB_TOKEN".into()),
+    let token = env::var("GITHUB_TOKEN")?;
+    let github = Github::new(
+        concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
+        Credentials::Token(token),
+    )?;
+    match github.users().authenticated().await {
+        Ok(me) => println!("{:#?}", me),
+        Err(err) => println!("err {:#?}", err),
     }
+
+    match github
+        .users()
+        .get(
+            env::var("GH_USERNAME")
+                .ok()
+                .unwrap_or_else(|| "bors".into()),
+        )
+        .await
+    {
+        Ok(user) => println!("{:#?}", user),
+        Err(err) => println!("err {:#?}", err),
+    }
+    Ok(())
 }

--- a/src/collaborators.rs
+++ b/src/collaborators.rs
@@ -1,6 +1,6 @@
-use self::super::{Error, Github};
 use crate::users::User;
-use crate::{ErrorKind, Future};
+use crate::Future;
+use crate::{Error, Github};
 use futures::prelude::*;
 use http::StatusCode;
 use std::collections::HashMap;
@@ -66,14 +66,11 @@ impl Collaborators {
                 .map_ok(|_| true)
                 .or_else(|err| async move {
                     match err {
-                        Error(
-                            ErrorKind::Fault {
-                                code: StatusCode::NOT_FOUND,
-                                ..
-                            },
-                            _,
-                        ) => Ok(false),
-                        Error(ErrorKind::Codec(_), _) => Ok(true),
+                        Error::Fault {
+                            code: StatusCode::NOT_FOUND,
+                            ..
+                        } => Ok(false),
+                        Error::Codec(_) => Ok(true),
                         otherwise => Err(otherwise),
                     }
                 }),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -763,7 +763,7 @@ impl Github {
                             let parsed_response = if status == StatusCode::NO_CONTENT { serde_json::from_str("null") } else { serde_json::from_slice::<Out>(&response_body) };
                             parsed_response
                                 .map(|out| (link, out))
-                                .map_err(|error| Error::Codec(error).into())
+                                .map_err(Error::Codec)
                         } else if status == StatusCode::NOT_MODIFIED {
                             // only supported case is when client provides if-none-match
                             // header when cargo builds with --cfg feature="httpcache"
@@ -811,7 +811,7 @@ impl Github {
                                     error: serde_json::from_slice(&response_body)?,
                                 },
                             };
-                            Err(error.into())
+                            Err(error)
                         }
                     }),
             )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,7 +143,7 @@ pub mod traffic;
 pub mod users;
 pub mod watching;
 
-pub use crate::errors::{Error, ErrorKind, Result};
+pub use crate::errors::{Error, Result};
 #[cfg(feature = "httpcache")]
 pub use crate::http_cache::{BoxedHttpCache, HttpCache};
 
@@ -763,7 +763,7 @@ impl Github {
                             let parsed_response = if status == StatusCode::NO_CONTENT { serde_json::from_str("null") } else { serde_json::from_slice::<Out>(&response_body) };
                             parsed_response
                                 .map(|out| (link, out))
-                                .map_err(|error| ErrorKind::Codec(error).into())
+                                .map_err(|error| Error::Codec(error).into())
                         } else if status == StatusCode::NOT_MODIFIED {
                             // only supported case is when client provides if-none-match
                             // header when cargo builds with --cfg feature="httpcache"
@@ -802,11 +802,11 @@ impl Github {
                                         .duration_since(UNIX_EPOCH)
                                         .unwrap()
                                         .as_secs();
-                                    ErrorKind::RateLimit {
+                                    Error::RateLimit {
                                         reset: Duration::from_secs(u64::from(reset) - now),
                                     }
                                 }
-                                _ => ErrorKind::Fault {
+                                _ => Error::Fault {
                                     code: status,
                                     error: serde_json::from_slice(&response_body)?,
                                 },
@@ -886,7 +886,7 @@ impl Github {
             )
             .or_else(|err| async move {
                 match err {
-                    Error(ErrorKind::Codec(_), _) => Ok(()),
+                    Error::Codec(_) => Ok(()),
                     otherwise => Err(otherwise),
                 }
             }),
@@ -904,7 +904,7 @@ impl Github {
             )
             .or_else(|err| async move {
                 match err {
-                    Error(ErrorKind::Codec(_), _) => Ok(()),
+                    Error::Codec(_) => Ok(()),
                     otherwise => Err(otherwise),
                 }
             }),
@@ -945,7 +945,7 @@ impl Github {
     fn patch_no_response(&self, uri: &str, message: Vec<u8>) -> Future<()> {
         Box::pin(self.patch(uri, message).or_else(|err| async move {
             match err {
-                Error(ErrorKind::Codec(_), _) => Ok(()),
+                Error::Codec(_) => Ok(()),
                 err => Err(err),
             }
         }))
@@ -974,7 +974,7 @@ impl Github {
     fn put_no_response(&self, uri: &str, message: Vec<u8>) -> Future<()> {
         Box::pin(self.put(uri, message).or_else(|err| async move {
             match err {
-                Error(ErrorKind::Codec(_), _) => Ok(()),
+                Error::Codec(_) => Ok(()),
                 err => Err(err),
             }
         }))

--- a/src/stars.rs
+++ b/src/stars.rs
@@ -2,7 +2,7 @@
 use futures::prelude::*;
 use http::StatusCode;
 
-use crate::{Error, ErrorKind, Future, Github};
+use crate::{Error, Future, Github};
 
 pub struct Stars {
     github: Github,
@@ -26,14 +26,11 @@ impl Stars {
                 .map_ok(|_| true)
                 .or_else(|err| async move {
                     match err {
-                        Error(
-                            ErrorKind::Fault {
-                                code: StatusCode::NOT_FOUND,
-                                ..
-                            },
-                            _,
-                        ) => Ok(false),
-                        Error(ErrorKind::Codec(_), _) => Ok(true),
+                        Error::Fault {
+                            code: StatusCode::NOT_FOUND,
+                            ..
+                        } => Ok(false),
+                        Error::Codec(_) => Ok(true),
                         otherwise => Err(otherwise),
                     }
                 }),


### PR DESCRIPTION
<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
2. This repository tries to stick with the community style conventions using [rustfmt](https://github.com/rust-lang-nursery/rustfmt#quick-start) with the *default* settings. If you have custom settings you may find that rustfmt
clutter the diff of your change with unrelated changes. Please apply formatting with `cargo  +nightly fmt` before submitting a pr.
-->

## What did you implement:

in prep for the next release. I'm taking the opportunity to trim a dependency on error_chain. The error crate ecosystem is a moving target and preferred error crates change from year to year. This should be an application choice not a library choice. As such I'm going to prefer errors that only implement the std error interface because it is the _standard_ error interface.

<!--
If this closes an open issue please replace xxx below with the issue number
-->

Closes: #xxx

#### How did you verify your change:

Unit tests and CI

#### What (if anything) would need to be called out in the CHANGELOG for the next release:

notes included