### PR TITLE
Use an EncodingKey that actually matches the header.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -378,7 +378,7 @@ impl ExpiringJWTCredential {
         let jwt = jwt::encode(
             &header,
             &payload,
-            &jsonwebtoken::EncodingKey::from_secret(private_key),
+            &jsonwebtoken::EncodingKey::from_rsa_der(private_key),
         )?;
 
         Ok(ExpiringJWTCredential {


### PR DESCRIPTION
The existing code triggers an error in `jsonwebtoken`; I really don't see how it could ever work.