### PR TITLE
fix README.md example

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ use hubcaps::{Credentials, Github};
 fn main() {
   let github = Github::new(
     "my-cool-user-agent/0.1.0",
-    Credentials::Token("personal-access-token"),
+    Credentials::Token("personal-access-token".to_string()),
   );
 }
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@
 //! let github = Github::new(
 //!   String::from("user-agent-name"),
 //!   Credentials::Token(
-//!     String::from("personal-access-token")
+//!     String::from("personal-access-token".to_string())
 //!   ),
 //! );
 //! ```


### PR DESCRIPTION
@softprops Thanks for the crate.

This PR is not so important but ... :)

The reason of the PR is that `Credentials::Token` can't be constructed from `&str` how displayed in `README.md`. Which disallows to use _copy&paste workflow_ :smile: 