### PR TITLE
catch httpcache compile error

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,6 +31,7 @@ jobs:
         uses: hecrj/setup-rust-action@v1
       - uses: actions/checkout@v2
       - run: cargo check --all
+      - run: cargo check --all --features httpcache
 
   test:
     needs: [codestyle, lint, compile]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Fix pagination for GitHub Enterprise [#247](https://github.com/softprops/hubcaps/pull/247)
 * Fix jsonwebtoken auth support [#264](https://github.com/softprops/hubcaps/pull/264)
+* Fix compile error with httpcache cargo feature [#270](https://github.com/softprops/hubcaps/pull/270)
 
 # 0.6.1
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -716,7 +716,7 @@ impl Github {
 
                 #[cfg(feature = "httpcache")]
                 let mut req = {
-                    let mut req = instance.client.request(method, url);
+                    let mut req = instance.client.request(method.clone(), url);
                     if method == Method::GET {
                         if let Ok(etag) = instance.http_cache.lookup_etag(&uri2) {
                             req = req.header(IF_NONE_MATCH, etag);


### PR DESCRIPTION



<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
2. This repository tries to stick with the community style conventions using [rustfmt](https://github.com/rust-lang-nursery/rustfmt#quick-start) with the *default* settings. If you have custom settings you may find that rustfmt
clutter the diff of your change with unrelated changes. Please apply formatting with `cargo  +nightly fmt` before submitting a pr.
-->

## What did you implement:

<!--
If this closes an open issue please replace xxx below with the issue number
-->

Closes: #269

Fixes an issue reported in #269 when cargo builds with the  httpcache feature is enabled is not compiling.

#### How did you verify your change:

Get ci to fail -> fix -> observe ci passing

<img width="1025" alt="Screen Shot 2020-09-06 at 12 43 32 AM" src="https://user-images.githubusercontent.com/2242/92318415-09876a80-efda-11ea-8037-3ae6e2620c30.png">


#### What (if anything) would need to be called out in the CHANGELOG for the next release: