### PR TITLE
Add serialize support for repo and user

### DIFF
--- a/src/repositories.rs
+++ b/src/repositories.rs
@@ -516,7 +516,7 @@ impl Repository {
 
 // representations (todo: replace with derive_builder)
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct Repo {
     pub id: u64,
     pub owner: User,

--- a/src/users.rs
+++ b/src/users.rs
@@ -1,9 +1,9 @@
 //! Users interface
 use crate::{Future, Github, Stream};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 /// User information
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct User {
     pub login: String,
     pub id: u64,


### PR DESCRIPTION
## What did you implement:

I'm using [tera](https://github.com/Keats/tera) and hubcaps for a new project. When trying to pass a `Vec<Repo>` to tera, I got an error that `Repo` didn't implement `Serialize`. 
Since `Deserialize` is already derived for that that type, I'd thought I'd add `Serialize` as well to fix the error. As far as I can see this shouldn't have any negative side-effects.

#### How did you verify your change:

Using my fork in the new project for now and serializing works as expected.
