### PR TITLE
Auth user emails

### DIFF
--- a/examples/users.rs
+++ b/examples/users.rs
@@ -27,5 +27,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
         Ok(user) => println!("{:#?}", user),
         Err(err) => println!("err {:#?}", err),
     }
+
+    match github.users().authenticated_emails().await {
+        Ok(emails) => println!("{:#?}", emails),
+        Err(err) => println!("err {:#?}", err),
+    }
+
     Ok(())
 }

--- a/src/users.rs
+++ b/src/users.rs
@@ -66,6 +66,7 @@ pub struct UserEmail {
     pub email: String,
     pub primary: bool,
     pub verified: bool,
+    pub visibility: Option<String>,
 }
 
 /// Query user information

--- a/src/users.rs
+++ b/src/users.rs
@@ -61,6 +61,13 @@ pub struct AuthenticatedUser {
     pub updated_at: String, // TODO: change to `DateTime`?
 }
 
+#[derive(Debug, Deserialize)]
+pub struct UserEmail {
+    pub email: String,
+    pub primary: bool,
+    pub verified: bool,
+}
+
 /// Query user information
 pub struct Users {
     github: Github,
@@ -74,6 +81,11 @@ impl Users {
     /// Information about current authenticated user
     pub fn authenticated(&self) -> Future<AuthenticatedUser> {
         self.github.get("/user")
+    }
+
+    /// Get current authenticated user's email list
+    pub fn authenticated_emails(&self) -> Future<Vec<UserEmail>> {
+        self.github.get("/user/emails")
     }
 
     pub fn get<U>(&self, username: U) -> Future<User>


### PR DESCRIPTION
<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
2. This repository tries to stick with the community style conventions using [rustfmt](https://github.com/rust-lang-nursery/rustfmt#quick-start) with the *default* settings. If you have custom settings you may find that rustfmt
clutter the diff of your change with unrelated changes. Please apply formatting with `cargo  +nightly fmt` before submitting a pr.
-->

## What did you implement:

1. Added "fn authenticated_emails" and "UserEmail" struct in "src/users.rs", which fetches from github's "/user/emails"
2. Added a usage example of the new function in "examples/users.rs"
<!--
If this closes an open issue please replace xxx below with the issue number
-->

Closes: #277 

#### How did you verify your change:

1. Since there isn't a generic test suite for api calls, I added it to "examples/users.rs" and eyeballed it.  

#### What (if anything) would need to be called out in the CHANGELOG for the next release:

1. A new users feature that allows getting "/user/emails"