### PR TITLE
Modifications to content API

### DIFF
--- a/examples/content.rs
+++ b/examples/content.rs
@@ -16,12 +16,12 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let repo = github.repo("softprops", "hubcaps");
 
     println!("License file:");
-    let license = repo.content().file("LICENSE").await?;
+    let license = repo.content().file("master", "LICENSE").await?;
     println!("{}", str::from_utf8(&license.content).unwrap());
 
     println!("Directory contents stream:");
     repo.content()
-        .iter("/examples")
+        .iter("master", "/examples")
         .try_for_each(|item| async move {
             println!("  {}", item.path);
             Ok(())
@@ -29,7 +29,12 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .await?;
 
     println!("Root directory:");
-    for item in repo.content().root().try_collect::<Vec<_>>().await? {
+    for item in repo
+        .content()
+        .root("master")
+        .try_collect::<Vec<_>>()
+        .await?
+    {
         println!("  {}", item.path)
     }
 

--- a/examples/repo_commits.rs
+++ b/examples/repo_commits.rs
@@ -17,7 +17,11 @@ async fn main() -> Result<()> {
     println!("Check out the first commit: {:#?}", first_commit);
 
     println!("Here are some more recent commits:");
-    let commits = github.repo("softprops", "hubcaps").commits().list().await?;
+    let commits = github
+        .repo("softprops", "hubcaps")
+        .commits()
+        .list("")
+        .await?;
     for commit in commits {
         println!(" - {}", commit.author.login);
     }

--- a/src/content.rs
+++ b/src/content.rs
@@ -71,9 +71,9 @@ impl Content {
 
     /// Creates a file at a specific location in a repository.
     /// You DO NOT need to base64 encode the content, we will do it for you.
-    pub fn create(&self, location: &str, content: &str, message: &str) -> Future<NewFileResponse> {
+    pub fn create(&self, location: &str, content: &[u8], message: &str) -> Future<NewFileResponse> {
         let file = &NewFile {
-            content: BASE64.encode(&content.to_string().into_bytes()),
+            content: BASE64.encode(content),
             message: message.to_string(),
             sha: None,
         };
@@ -85,12 +85,12 @@ impl Content {
     pub fn update(
         &self,
         location: &str,
-        content: &str,
+        content: &[u8],
         message: &str,
         sha: &str,
     ) -> Future<NewFileResponse> {
         let file = &NewFile {
-            content: BASE64.encode(&content.to_string().into_bytes()),
+            content: BASE64.encode(content),
             message: message.to_string(),
             sha: Some(sha.to_string()),
         };

--- a/src/content.rs
+++ b/src/content.rs
@@ -31,38 +31,42 @@ impl Content {
         }
     }
 
-    fn path(&self, location: &str) -> String {
+    fn path(&self, location: &str, ref_: &str) -> String {
         // Handle files with spaces and other characters that can mess up the
         // final URL.
         let location = percent_encode(location.as_ref(), PATH);
-        format!("/repos/{}/{}/contents{}", self.owner, self.repo, location)
+        let mut path = format!("/repos/{}/{}/contents{}", self.owner, self.repo, location);
+        if !ref_.is_empty() {
+            path += &format!("?ref={}", ref_);
+        }
+        path
     }
 
     /// Gets the contents of the location. This could be a file, symlink, or
     /// submodule. To list the contents of a directory, use `iter`.
-    pub fn get(&self, location: &str) -> Future<Contents> {
-        self.github.get(&self.path(location))
+    pub fn get(&self, location: &str, ref_: &str) -> Future<Contents> {
+        self.github.get(&self.path(location, ref_))
     }
 
     /// Information on a single file.
     ///
     /// GitHub only supports downloading files up to 1 megabyte in size. If you
     /// need to retrieve larger files, the Git Data API must be used instead.
-    pub fn file(&self, location: &str) -> Future<File> {
-        self.github.get(&self.path(location))
+    pub fn file(&self, location: &str, ref_: &str) -> Future<File> {
+        self.github.get(&self.path(location, ref_))
     }
 
     /// List the root directory.
-    pub fn root(&self) -> Stream<DirectoryItem> {
-        self.iter("/")
+    pub fn root(&self, ref_: &str) -> Stream<DirectoryItem> {
+        self.iter("/", ref_)
     }
 
     /// Provides a stream over the directory items in `location`.
     ///
     /// GitHub limits the number of items returned to 1000 for this API. If you
     /// need to retrieve more items, the Git Data API must be used instead.
-    pub fn iter(&self, location: &str) -> Stream<DirectoryItem> {
-        self.github.get_stream(&self.path(location))
+    pub fn iter(&self, location: &str, ref_: &str) -> Stream<DirectoryItem> {
+        self.github.get_stream(&self.path(location, ref_))
     }
 
     /// Creates a file at a specific location in a repository.
@@ -73,7 +77,7 @@ impl Content {
             message: message.to_string(),
             sha: None,
         };
-        self.github.put(&self.path(location), json!(file))
+        self.github.put(&self.path(location, ""), json!(file))
     }
 
     /// Updates a file at a specific location in a repository.
@@ -90,7 +94,7 @@ impl Content {
             message: message.to_string(),
             sha: Some(sha.to_string()),
         };
-        self.github.put(&self.path(location), json!(file))
+        self.github.put(&self.path(location, ""), json!(file))
     }
 }
 

--- a/src/repo_commits.rs
+++ b/src/repo_commits.rs
@@ -28,8 +28,11 @@ impl RepoCommits {
 
     /// list repo commits
     /// !!! make optional parameters
-    pub fn list(&self) -> Future<Vec<RepoCommit>> {
-        let uri = format!("/repos/{}/{}/commits", self.owner, self.repo);
+    pub fn list(&self, path: &str) -> Future<Vec<RepoCommit>> {
+        let mut uri = format!("/repos/{}/{}/commits", self.owner, self.repo);
+        if !path.is_empty() {
+            uri += &format!("?path={}", path);
+        }
         self.github.get::<Vec<RepoCommit>>(&uri)
     }
 


### PR DESCRIPTION
#### What did you implement:

- Allow getting repo contents for files from specific branches
- Allow updating and creating files with binary content by sending bytes


#### How did you verify your change:

Already using it in our bots and apps.

#### What (if anything) would need to be called out in the CHANGELOG for the next release:

- Allow getting repo contents for files from specific branches
- Allow updating and creating files with binary content by sending bytes