### PR TITLE
Update deps: tokio 1.0, reqwest 0.11 etc.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,20 +17,20 @@ maintenance = { status = "actively-developed" }
 
 [dev-dependencies]
 pretty_env_logger = "0.4"
-tokio = { version = "0.2", features = ["macros", "rt-threaded"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 
 [dependencies]
-base64 = "0.12"
+base64 = "0.13"
 data-encoding = "2"
 dirs = { version = "3.0", optional = true }
-futures = "0.3"
+futures = { version = "0.3", default-features = false }
 http = "0.2"
 hyperx = "1"
 jsonwebtoken = "7"
 log = "0.4"
 mime = "0.3"
 percent-encoding = "2"
-reqwest = { version = "0.10", default-features = false }
+reqwest = { version = "0.11", default-features = false }
 serde = { version = "1.0", features = ['derive'] }
 serde_derive = "1.0"
 serde_json = "1.0"


### PR DESCRIPTION
I also tuned the `futures` dependency to no longer pull in `futures-executor` crate

Closes: #283 
Closes: #276 