### PR TITLE
CheckRun: i32 -> u64 for id

### DIFF
--- a/src/checks.rs
+++ b/src/checks.rs
@@ -183,7 +183,7 @@ pub struct CheckRunUpdateOptions {
 
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub struct CheckRun {
-    pub id: i32,
+    pub id: u64,
     pub name: String,
     pub head_sha: String,
     pub url: String,


### PR DESCRIPTION
## What did you implement:

I replaced the CheckRun id field from i32 to u64 since CheckRun IDs cannot fit in an `i32` anymore, preventing us from loading recent CheckRuns.

Closes: #289 

#### How did you verify your change:

I ran cargo test (Though I'm not sure the tests are hitting that code)

#### What (if anything) would need to be called out in the CHANGELOG for the next release:

BREAKING CHANGE: CheckRun id is now a `u64` instead of a `i32` to accommodate the IDs returned by GitHub.