### PR TITLE
Add PullRequest::iter_files

### DIFF
--- a/src/pulls.rs
+++ b/src/pulls.rs
@@ -258,7 +258,6 @@ pub struct Pull {
     pub assignee: Option<User>,
     pub assignees: Vec<User>,
     pub merge_commit_sha: Option<String>,
-    pub merged: bool,
     pub mergeable: Option<bool>,
     pub merged_by: Option<User>,
     pub comments: Option<u64>,

--- a/src/pulls.rs
+++ b/src/pulls.rs
@@ -115,9 +115,17 @@ impl PullRequest {
         self.github.patch::<Pull>(&self.path(""), json!(pr))
     }
 
-    /// Returns a vector of file diffs associated with this pull
+    /// Returns a vector of file diffs associated with this pull request
+    #[deprecated(
+        note = "This only returns the first page of results; up to 30 entries. Use `iter_files` instead"
+    )]
     pub fn files(&self) -> Future<Vec<FileDiff>> {
         self.github.get(&self.path("/files"))
+    }
+
+    /// Returns a stream of file diffs associated with this pull request
+    pub fn iter_files(&self) -> Stream<FileDiff> {
+        self.github.get_stream(&self.path("/files"))
     }
 
     /// returns issue comments interface


### PR DESCRIPTION

## What did you implement:

- Added `PullRequest::iter_files`
- Deprecated `PullRequest::files`

If you're okay with breaking changes, I think simply changing the return type of `PullRequest::files` would be the better solution.

Closes #296

#### How did you verify your change:

Dogfooding

#### What (if anything) would need to be called out in the CHANGELOG for the next release:

- Added `PullRequest::iter_files`
- Deprecated `PullRequest::files`
