### PR TITLE
Make JWT functionality optional with features

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,6 +29,8 @@ jobs:
           components: clippy
       - uses: actions/checkout@v2
       - run: cargo clippy --all-targets -- -D clippy::all
+      - run: cargo clippy --no-default-features -- -D clippy::all
+      - run: cargo clippy --no-default-features --features=jwt -- -D clippy::all
 
   compile:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ dirs = { version = "3.0", optional = true }
 futures = { version = "0.3", default-features = false }
 http = "0.2"
 hyperx = "1"
-jsonwebtoken = "7"
+jsonwebtoken = { version = "7", optional = true }
 log = "0.4"
 mime = "0.3"
 percent-encoding = "2"
@@ -37,9 +37,11 @@ serde_json = "1.0"
 url = "2"
 
 [features]
-default = ["default-tls"]
+default = ["app", "default-tls"]
 # enable native tls
 default-tls = ["reqwest/default-tls"]
+app = ["jwt"]
+jwt = ["jsonwebtoken"]
 # enable rustls
 rustls-tls = ["reqwest/rustls-tls"]
 # enable etag-based http_cache functionality

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,5 +1,6 @@
-//! Labels interface
+use crate::jwt::JWTCredentials;
 use serde::Deserialize;
+use std::sync::{Arc, Mutex};
 
 use self::super::{AuthenticationConstraint, Future, Github, MediaType};
 
@@ -61,4 +62,47 @@ pub struct Installation {
     // created_at, updated_at
     pub single_file_name: Option<String>,
     pub repository_selection: String,
+}
+
+/// A caching token "generator" which contains JWT credentials.
+///
+/// The authentication mechanism in the GitHub client library
+/// determines if the token is stale, and if so, uses the contained
+/// JWT credentials to fetch a new installation token.
+///
+/// The Mutex<Option> access key is for interior mutability.
+#[derive(Debug, Clone)]
+pub struct InstallationTokenGenerator {
+    pub installation_id: u64,
+    pub jwt_credential: Box<crate::Credentials>,
+    pub(crate) access_key: Arc<Mutex<Option<String>>>,
+}
+
+impl InstallationTokenGenerator {
+    pub fn new(installation_id: u64, creds: JWTCredentials) -> InstallationTokenGenerator {
+        InstallationTokenGenerator {
+            installation_id,
+            jwt_credential: Box::new(crate::Credentials::JWT(creds)),
+            access_key: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    pub(crate) fn token(&self) -> Option<String> {
+        if let crate::Credentials::JWT(ref creds) = *self.jwt_credential {
+            if creds.is_stale() {
+                return None;
+            }
+        }
+        self.access_key.lock().unwrap().clone()
+    }
+
+    pub(crate) fn jwt(&self) -> &crate::Credentials {
+        &*self.jwt_credential
+    }
+}
+
+impl PartialEq for InstallationTokenGenerator {
+    fn eq(&self, other: &InstallationTokenGenerator) -> bool {
+        self.installation_id == other.installation_id && self.jwt_credential == other.jwt_credential
+    }
 }

--- a/src/content.rs
+++ b/src/content.rs
@@ -210,9 +210,9 @@ pub struct Links {
 #[derive(Debug)]
 pub struct DecodedContents(Vec<u8>);
 
-impl Into<Vec<u8>> for DecodedContents {
-    fn into(self) -> Vec<u8> {
-        self.0
+impl From<DecodedContents> for Vec<u8> {
+    fn from(DecodedContents(bytes): DecodedContents) -> Vec<u8> {
+        bytes
     }
 }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,4 +1,5 @@
 //! Client errors
+#[cfg(feature = "jwt")]
 use crate::jwt::errors::Error as JWTError;
 use http::StatusCode;
 use reqwest::Error as ReqwestError;
@@ -31,6 +32,8 @@ pub enum Error {
     Url(ParseError),
     /// Network errors
     IO(IoError),
+
+    #[cfg(feature = "jwt")]
     /// JWT validation errors
     JWT(JWTError),
 }
@@ -59,6 +62,7 @@ impl From<IoError> for Error {
     }
 }
 
+#[cfg(feature = "jwt")]
 impl From<JWTError> for Error {
     fn from(err: JWTError) -> Self {
         Error::JWT(err)
@@ -72,6 +76,7 @@ impl StdError for Error {
             Error::Reqwest(err) => Some(err),
             Error::Url(err) => Some(err),
             Error::IO(err) => Some(err),
+            #[cfg(feature = "jwt")]
             Error::JWT(err) => Some(err),
             _ => None,
         }
@@ -91,6 +96,7 @@ impl fmt::Display for Error {
             Error::Reqwest(err) => write!(f, "{}", err),
             Error::Url(err) => write!(f, "{}", err),
             Error::IO(err) => write!(f, "{}", err),
+            #[cfg(feature = "jwt")]
             Error::JWT(err) => write!(f, "{}", err),
         }
     }

--- a/src/jwt.rs
+++ b/src/jwt.rs
@@ -1,0 +1,111 @@
+use crate::errors::Result;
+use jsonwebtoken as jwt;
+use serde::Serialize;
+use std::sync::{Arc, Mutex};
+use std::time;
+
+pub use jsonwebtoken::errors;
+
+// We use 9 minutes for the life to give some buffer for clock drift between
+// our clock and GitHub's. The absolute max is 10 minutes.
+const MAX_JWT_TOKEN_LIFE: time::Duration = time::Duration::from_secs(60 * 9);
+
+// 8 minutes so we refresh sooner than it actually expires
+const JWT_TOKEN_REFRESH_PERIOD: time::Duration = time::Duration::from_secs(60 * 8);
+
+/// JSON Web Token authentication mechanism
+///
+/// The GitHub client methods are all &self, but the dynamically
+/// generated JWT token changes regularly. The token is also a bit
+/// expensive to regenerate, so we do want to have a mutable cache.
+///
+/// We use a token inside a Mutex so we can have interior mutability
+/// even though JWTCredentials is not mutable.
+#[derive(Clone)]
+pub struct JWTCredentials {
+    pub app_id: u64,
+    /// DER RSA key. Generate with
+    /// `openssl rsa -in private_rsa_key.pem -outform DER -out private_rsa_key.der`
+    pub private_key: Vec<u8>,
+    cache: Arc<Mutex<ExpiringJWTCredential>>,
+}
+
+impl JWTCredentials {
+    pub fn new(app_id: u64, private_key: Vec<u8>) -> Result<JWTCredentials> {
+        let creds = ExpiringJWTCredential::calculate(app_id, &private_key)?;
+
+        Ok(JWTCredentials {
+            app_id,
+            private_key,
+            cache: Arc::new(Mutex::new(creds)),
+        })
+    }
+
+    #[cfg(feature = "app")]
+    pub(crate) fn is_stale(&self) -> bool {
+        self.cache.lock().unwrap().is_stale()
+    }
+
+    /// Fetch a valid JWT token, regenerating it if necessary
+    pub fn token(&self) -> String {
+        let mut expiring = self.cache.lock().unwrap();
+        if expiring.is_stale() {
+            *expiring = ExpiringJWTCredential::calculate(self.app_id, &self.private_key)
+                .expect("JWT private key worked before, it should work now...");
+        }
+
+        expiring.token.clone()
+    }
+}
+
+impl PartialEq for JWTCredentials {
+    fn eq(&self, other: &JWTCredentials) -> bool {
+        self.app_id == other.app_id && self.private_key == other.private_key
+    }
+}
+
+#[derive(Debug)]
+struct ExpiringJWTCredential {
+    token: String,
+    created_at: time::Instant,
+}
+
+#[derive(Serialize)]
+struct JWTCredentialClaim {
+    iat: u64,
+    exp: u64,
+    iss: u64,
+}
+
+impl ExpiringJWTCredential {
+    fn calculate(app_id: u64, private_key: &[u8]) -> Result<ExpiringJWTCredential> {
+        // SystemTime can go backwards, Instant can't, so always use
+        // Instant for ensuring regular cycling.
+        let created_at = time::Instant::now();
+        let now = time::SystemTime::now()
+            .duration_since(time::UNIX_EPOCH)
+            .unwrap();
+        let expires = now + MAX_JWT_TOKEN_LIFE;
+
+        let payload = JWTCredentialClaim {
+            iat: now.as_secs(),
+            exp: expires.as_secs(),
+            iss: app_id,
+        };
+        let header = jwt::Header::new(jwt::Algorithm::RS256);
+        let jwt = jwt::encode(
+            &header,
+            &payload,
+            &jsonwebtoken::EncodingKey::from_rsa_der(private_key),
+        )?;
+
+        Ok(ExpiringJWTCredential {
+            created_at,
+            token: jwt,
+        })
+    }
+
+    fn is_stale(&self) -> bool {
+        self.created_at.elapsed() >= JWT_TOKEN_REFRESH_PERIOD
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,8 +83,6 @@
 use std::fmt;
 use std::pin::Pin;
 use std::str::FromStr;
-use std::sync::{Arc, Mutex};
-use std::time;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use futures::{future, prelude::*, stream, Future as StdFuture, Stream as StdStream};
@@ -96,13 +94,11 @@ use http::{Method, StatusCode};
 #[cfg(feature = "httpcache")]
 use hyperx::header::LinkValue;
 use hyperx::header::{qitem, Link, RelationType};
-use jsonwebtoken as jwt;
-use log::{debug, error, trace};
+use log::{debug, trace};
 use mime::Mime;
 use reqwest::Url;
 use reqwest::{Body, Client};
 use serde::de::DeserializeOwned;
-use serde::Serialize;
 
 #[doc(hidden)] // public for doc testing and integration testing only
 #[cfg(feature = "httpcache")]
@@ -110,6 +106,7 @@ pub mod http_cache;
 #[macro_use]
 mod macros; // expose json! macro to child modules
 pub mod activity;
+#[cfg(feature = "app")]
 pub mod app;
 pub mod branches;
 pub mod checks;
@@ -122,6 +119,8 @@ pub mod gists;
 pub mod git;
 pub mod hooks;
 pub mod issues;
+#[cfg(feature = "jwt")]
+mod jwt;
 pub mod keys;
 pub mod labels;
 pub mod membership;
@@ -148,8 +147,13 @@ pub use crate::errors::{Error, Result};
 pub use crate::http_cache::{BoxedHttpCache, HttpCache};
 
 use crate::activity::Activity;
+#[cfg(feature = "app")]
 use crate::app::App;
+#[cfg(feature = "app")]
+pub use crate::app::InstallationTokenGenerator;
 use crate::gists::{Gists, UserGists};
+#[cfg(feature = "jwt")]
+pub use crate::jwt::JWTCredentials;
 use crate::organizations::{Organization, Organizations, UserOrganizations};
 use crate::rate_limit::RateLimit;
 use crate::repositories::{OrganizationRepositories, Repositories, Repository, UserRepositories};
@@ -157,11 +161,6 @@ use crate::search::Search;
 use crate::users::Users;
 
 const DEFAULT_HOST: &str = "https://api.github.com";
-// We use 9 minutes for the life to give some buffer for clock drift between
-// our clock and GitHub's. The absolute max is 10 minutes.
-const MAX_JWT_TOKEN_LIFE: time::Duration = time::Duration::from_secs(60 * 9);
-// 8 minutes so we refresh sooner than it actually expires
-const JWT_TOKEN_REFRESH_PERIOD: time::Duration = time::Duration::from_secs(60 * 8);
 
 /// A type alias for `Futures` that may return `hubcaps::Errors`
 pub type Future<T> = Pin<Box<dyn StdFuture<Output = Result<T>> + Send>>;
@@ -223,6 +222,7 @@ impl From<MediaType> for Mime {
 pub enum AuthenticationConstraint {
     /// No constraint
     Unconstrained,
+    #[cfg(feature = "jwt")]
     /// Must be JWT
     JWT,
 }
@@ -261,10 +261,12 @@ pub enum Credentials {
     /// Oauth client id and secret
     /// https://developer.github.com/v3/#oauth2-keysecret
     Client(String, String),
+    #[cfg(feature = "jwt")]
     /// JWT token exchange, to be performed transparently in the
     /// background. app-id, DER key-file.
     /// https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/
     JWT(JWTCredentials),
+    #[cfg(feature = "app")]
     /// JWT-based App Installation Token
     /// https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/
     InstallationToken(InstallationTokenGenerator),
@@ -282,156 +284,19 @@ impl fmt::Debug for Credentials {
                 .field(&id)
                 .field(&"*".repeat(secret.len()))
                 .finish(),
+            #[cfg(feature = "jwt")]
             Credentials::JWT(jwt) => f
                 .debug_struct("Credentials::JWT")
                 .field("app_id", &jwt.app_id)
                 .field("private_key", &"vec![***]")
                 .finish(),
+            #[cfg(feature = "app")]
             Credentials::InstallationToken(generator) => f
                 .debug_struct("Credentials::InstallationToken")
                 .field("installation_id", &generator.installation_id)
                 .field("jwt_credential", &"***")
                 .finish(),
         }
-    }
-}
-
-/// JSON Web Token authentication mechanism
-///
-/// The GitHub client methods are all &self, but the dynamically
-/// generated JWT token changes regularly. The token is also a bit
-/// expensive to regenerate, so we do want to have a mutable cache.
-///
-/// We use a token inside a Mutex so we can have interior mutability
-/// even though JWTCredentials is not mutable.
-#[derive(Clone)]
-pub struct JWTCredentials {
-    pub app_id: u64,
-    /// DER RSA key. Generate with
-    /// `openssl rsa -in private_rsa_key.pem -outform DER -out private_rsa_key.der`
-    pub private_key: Vec<u8>,
-    cache: Arc<Mutex<ExpiringJWTCredential>>,
-}
-
-impl JWTCredentials {
-    pub fn new(app_id: u64, private_key: Vec<u8>) -> Result<JWTCredentials> {
-        let creds = ExpiringJWTCredential::calculate(app_id, &private_key)?;
-
-        Ok(JWTCredentials {
-            app_id,
-            private_key,
-            cache: Arc::new(Mutex::new(creds)),
-        })
-    }
-
-    fn is_stale(&self) -> bool {
-        self.cache.lock().unwrap().is_stale()
-    }
-
-    /// Fetch a valid JWT token, regenerating it if necessary
-    pub fn token(&self) -> String {
-        let mut expiring = self.cache.lock().unwrap();
-        if expiring.is_stale() {
-            *expiring = ExpiringJWTCredential::calculate(self.app_id, &self.private_key)
-                .expect("JWT private key worked before, it should work now...");
-        }
-
-        expiring.token.clone()
-    }
-}
-
-impl PartialEq for JWTCredentials {
-    fn eq(&self, other: &JWTCredentials) -> bool {
-        self.app_id == other.app_id && self.private_key == other.private_key
-    }
-}
-
-#[derive(Debug)]
-struct ExpiringJWTCredential {
-    token: String,
-    created_at: time::Instant,
-}
-
-#[derive(Serialize)]
-struct JWTCredentialClaim {
-    iat: u64,
-    exp: u64,
-    iss: u64,
-}
-
-impl ExpiringJWTCredential {
-    fn calculate(app_id: u64, private_key: &[u8]) -> Result<ExpiringJWTCredential> {
-        // SystemTime can go backwards, Instant can't, so always use
-        // Instant for ensuring regular cycling.
-        let created_at = time::Instant::now();
-        let now = time::SystemTime::now()
-            .duration_since(time::UNIX_EPOCH)
-            .unwrap();
-        let expires = now + MAX_JWT_TOKEN_LIFE;
-
-        let payload = JWTCredentialClaim {
-            iat: now.as_secs(),
-            exp: expires.as_secs(),
-            iss: app_id,
-        };
-        let header = jwt::Header::new(jwt::Algorithm::RS256);
-        let jwt = jwt::encode(
-            &header,
-            &payload,
-            &jsonwebtoken::EncodingKey::from_rsa_der(private_key),
-        )?;
-
-        Ok(ExpiringJWTCredential {
-            created_at,
-            token: jwt,
-        })
-    }
-
-    fn is_stale(&self) -> bool {
-        self.created_at.elapsed() >= JWT_TOKEN_REFRESH_PERIOD
-    }
-}
-
-/// A caching token "generator" which contains JWT credentials.
-///
-/// The authentication mechanism in the GitHub client library
-/// determines if the token is stale, and if so, uses the contained
-/// JWT credentials to fetch a new installation token.
-///
-/// The Mutex<Option> access key is for interior mutability.
-#[derive(Debug, Clone)]
-pub struct InstallationTokenGenerator {
-    pub installation_id: u64,
-    pub jwt_credential: Box<Credentials>,
-    access_key: Arc<Mutex<Option<String>>>,
-}
-
-impl InstallationTokenGenerator {
-    pub fn new(installation_id: u64, creds: JWTCredentials) -> InstallationTokenGenerator {
-        InstallationTokenGenerator {
-            installation_id,
-            jwt_credential: Box::new(Credentials::JWT(creds)),
-            access_key: Arc::new(Mutex::new(None)),
-        }
-    }
-
-    fn token(&self) -> Option<String> {
-        if let Credentials::JWT(ref creds) = *self.jwt_credential {
-            if creds.is_stale() {
-                return None;
-            }
-        }
-        self.access_key.lock().unwrap().clone()
-    }
-
-    fn jwt(&self) -> &Credentials {
-        &*self.jwt_credential
-    }
-}
-
-impl PartialEq for InstallationTokenGenerator {
-    fn eq(&self, other: &InstallationTokenGenerator) -> bool {
-        self.installation_id == other.installation_id && self.jwt_credential == other.jwt_credential
     }
 }
 
@@ -612,6 +477,7 @@ impl Github {
     }
 
     /// Return a reference to GitHub Apps
+    #[cfg(feature = "app")]
     pub fn app(&self) -> App {
         App::new(self.clone())
     }
@@ -619,13 +485,16 @@ impl Github {
     fn credentials(&self, authentication: AuthenticationConstraint) -> Option<&Credentials> {
         match (authentication, self.credentials.as_ref()) {
             (AuthenticationConstraint::Unconstrained, creds) => creds,
+            #[cfg(feature = "jwt")]
             (AuthenticationConstraint::JWT, creds @ Some(&Credentials::JWT(_))) => creds,
+            #[cfg(feature = "app")]
             (
                 AuthenticationConstraint::JWT,
                 Some(&Credentials::InstallationToken(ref apptoken)),
             ) => Some(apptoken.jwt()),
+            #[cfg(feature = "jwt")]
             (AuthenticationConstraint::JWT, creds) => {
-                error!(
+                log::error!(
                     "Request needs JWT authentication but only {:?} available",
                     creds
                 );
@@ -658,12 +527,14 @@ impl Github {
                     parsed_url.map(|u| (u, Some(auth))).map_err(Error::from),
                 ))
             }
+            #[cfg(feature = "jwt")]
             Some(&Credentials::JWT(ref jwt)) => {
                 let auth = format!("Bearer {}", jwt.token());
                 Box::pin(future::ready(
                     parsed_url.map(|u| (u, Some(auth))).map_err(Error::from),
                 ))
             }
+            #[cfg(feature = "app")]
             Some(&Credentials::InstallationToken(ref apptoken)) => {
                 if let Some(token) = apptoken.token() {
                     let auth = format!("token {}", token);


### PR DESCRIPTION
## Problem

JWT support is not always needed. For instance, when writing something
like a GitHub Action, we can rely on PAT authentication and will never
need JWT.

JWT support currently requires `jsonwebtoken` v7, which currently has
several older dependencies (including base64, ring, etc). These
dependencies are updated in `jsonwebtoken` v8 (currently in
beta-status). The v8 branch has been in development for nearly two
years.

## Solution

This change makes these dependencies optional by adding two new
features: `jwt` and `app`. The `app` feature depends on `jwt` and is
enabled by default to avoid making a backwards-incompatible change. This
allows users to avoid these dependencies by using `default-features =
false`.

This change moves JWT-specific types out of `lib.rs` into a `jwt` module
so they can be feature-gated together, as much as possible.

This change also updates CI to run `clippy` with no default features and
with only the `jwt` feature to ensure that these configurations don't
break.

#### How did you verify your change:

I've used this branch in a project I'm working on, https://github.com/olix0r/rustsecbot.

#### What (if anything) would need to be called out in the CHANGELOG for the next release:

`jsonwebtoken` is now an optional dependency that can be omitted by disabling default features.