### PR TITLE
checks.rs: add skipped conclusion

### DIFF
--- a/src/checks.rs
+++ b/src/checks.rs
@@ -79,6 +79,7 @@ pub enum CheckRunState {
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum Conclusion {
+    Skipped,
     Success,
     Failure,
     Neutral,


### PR DESCRIPTION
one of action_required, cancelled, failure, neutral, success, skipped, stale, or timed_out
stale can only be set by github itself so it does not need to be listed
https://docs.github.com/en/rest/reference/checks#create-a-check-run

<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
2. This repository tries to stick with the community style conventions using [rustfmt](https://github.com/rust-lang-nursery/rustfmt#quick-start) with the *default* settings. If you have custom settings you may find that rustfmt
clutter the diff of your change with unrelated changes. Please apply formatting with `cargo  +nightly fmt` before submitting a pr.
-->

## What did you implement:

the skipped conclusion
<!--
If this closes an open issue please replace xxx below with the issue number
-->

Closes: #xxx

#### How did you verify your change:
i have not verified it other than looking at the github docs
i confirmed that `cargo check --all` runs

#### What (if anything) would need to be called out in the CHANGELOG for the next release: