### PR TITLE
Add `UserGists::iter`, `Gists::iter`

### DIFF
--- a/src/gists.rs
+++ b/src/gists.rs
@@ -1,6 +1,6 @@
 //! Gists interface
 use crate::users::User;
-use crate::{Future, Github};
+use crate::{Future, Github, Stream};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::hash::Hash;
@@ -30,6 +30,14 @@ impl UserGists {
             uri.push(query);
         }
         self.github.get(&uri.join("?"))
+    }
+
+    pub fn iter(&self, options: &GistListOptions) -> Stream<Gist> {
+        let mut uri = vec![format!("/users/{}/gists", self.owner)];
+        if let Some(query) = options.serialize() {
+            uri.push(query);
+        }
+        self.github.get_stream(&uri.join("?"))
     }
 }
 
@@ -83,6 +91,14 @@ impl Gists {
             uri.push(query);
         }
         self.github.get::<Vec<Gist>>(&uri.join("?"))
+    }
+
+    pub fn iter(&self, options: &GistListOptions) -> Stream<Gist> {
+        let mut uri = vec![self.path("")];
+        if let Some(query) = options.serialize() {
+            uri.push(query);
+        }
+        self.github.get_stream(&uri.join("?"))
     }
 
     pub fn public(&self) -> Future<Vec<Gist>> {


### PR DESCRIPTION
Return streams of gists, allowing traversing all of the gists that belong to a user or match the given `GistListOptions`

<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
2. This repository tries to stick with the community style conventions using [rustfmt](https://github.com/rust-lang-nursery/rustfmt#quick-start) with the *default* settings. If you have custom settings you may find that rustfmt
clutter the diff of your change with unrelated changes. Please apply formatting with `cargo  +nightly fmt` before submitting a pr.
-->

## What did you implement:

Extend the `UserGists`, `Gists` impls with an `iter()` functions that return `Stream<Gist>`.

#### How did you verify your change:
I ran the example code that pulls a user's gists, initially it returned only 30 gists, but it returns all of my gists now (when modified to user `UserGists::iter()`).

The test was run with both the default github endpoint, and an enterprise endpoint.

I'd be happy to add an example demonstrating this as well.

#### What (if anything) would need to be called out in the CHANGELOG for the next release:


- Add `UserGists::iter(owner, options)` to return a stream of gists with the given owner and options.
- Add `Gists::iter(options)` to return a stream of gists matching the given options

cc: @softprops @dwijnand