### PR TITLE
Allow larger ids for CheckSuite.id deserialization

### DIFF
--- a/src/checks.rs
+++ b/src/checks.rs
@@ -218,5 +218,5 @@ pub struct CheckRun {
 
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub struct CheckSuite {
-    pub id: u32,
+    pub id: u64,
 }


### PR DESCRIPTION
<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
2. This repository tries to stick with the community style conventions using [rustfmt](https://github.com/rust-lang-nursery/rustfmt#quick-start) with the *default* settings. If you have custom settings you may find that rustfmt
clutter the diff of your change with unrelated changes. Please apply formatting with `cargo  +nightly fmt` before submitting a pr.
-->

## What did you implement:

Changed `CheckSuite` property, `id` from `u32` to `u64` in order to properly deserialize Github API responses which have ids that are now larger than `u32`. 

⚠️  This is a breaking change for any consumers of this class.

<!--
If this closes an open issue please replace xxx below with the issue number
-->


#### How did you verify your change:

* Derserialized responses from active GitHub CheckSuites

#### What (if anything) would need to be called out in the CHANGELOG for the next release:

* `CheckSuite.id` changed from `u32`->`u64`